### PR TITLE
Catching OSError in case of os.stat failure.

### DIFF
--- a/scripts/idle.py
+++ b/scripts/idle.py
@@ -41,8 +41,11 @@ class WorkspaceScanner(object):
         for root, dirs, files in os.walk(self.top):
             for f in files:
                 if f.endswith('.go'):
-                    stats = os.stat(os.path.join(root, f))
-                    yield stats.st_mtime + stats.st_size
+                    try:
+                        stats = os.stat(os.path.join(root, f))
+                        yield stats.st_mtime + stats.st_size
+                    except OSError:
+                        pass
 
 
 class TestRunner(object):


### PR DESCRIPTION
os.stat fails in some cases.
For example, 
- emacs lock file (`.#filename.go`)
- file deletion

Writing notice log may be better, but it can be too verbose when emacs creates a lock file.
