### PR TITLE
Add 'testdata' and '_*' to the list of directories to ignore.

### DIFF
--- a/web/server/system/file_system.go
+++ b/web/server/system/file_system.go
@@ -25,7 +25,8 @@ func (self *FileSystem) Walk(root string, step filepath.WalkFunc) {
 }
 
 func (self *FileSystem) isMetaDirectory(info os.FileInfo) bool {
-	return info.IsDir() && strings.HasPrefix(info.Name(), ".")
+	name := info.Name()
+	return info.IsDir() && (strings.HasPrefix(name, ".") || strings.HasPrefix(name, "_") || name == "testdata")
 }
 
 func (self *FileSystem) Exists(directory string) bool {


### PR DESCRIPTION
This matches the behaviour of the rest of the go toolchain.
