### PR TITLE
FIX: prevent panic when line does not contain ':'

### DIFF
--- a/web/server/parser/testParser.go
+++ b/web/server/parser/testParser.go
@@ -106,7 +106,9 @@ func (self *testParser) parsePanicLocation(index int, line string) {
 	fields := strings.Split(metaLine, " ")
 	fileAndLine := strings.Split(fields[0], ":")
 	self.test.File = fileAndLine[0]
-	self.test.Line, _ = strconv.Atoi(fileAndLine[1])
+	if len(fileAndLine) > 1 {
+		self.test.Line, _ = strconv.Atoi(fileAndLine[1])
+	}
 }
 func (self *testParser) preserveStackTraceIndentation(index int, line string) {
 	if panicLineShouldBeIndented(index, line) {


### PR DESCRIPTION
It's possible that the parsing of the output did not contain a colon.
This should possibly be handled elsewhere, but as a stogap measure,
wrong input should not be able to panic from within this function.

output which triggered bug was a permission error:

```
Potential error parsing output of /Users/tim/mlog/go ; couldn't handle
this stray line: go install mlog/util: open
/Users/tim/mlog/go/pkg/darwin_amd64/mlog/util.a: permission denied

trace:
panic: runtime error: index out of range

goroutine 4 [running]:
github.com/smartystreets/goconvey/web/server/parser.(*testParser).parsePanicLocation(0xc200131900, 0x4, 0xc20017b4b0, 0x17)
        /Users/tim/mlog/go/src/github.com/smartystreets/goconvey/web/server/parser/testParser.go:109 +0x147
github.com/smartystreets/goconvey/web/server/parser.(*testParser).parsePanicOutput(0xc200131900)
        /Users/tim/mlog/go/src/github.com/smartystreets/goconvey/web/server/parser/testParser.go:96 +0xbc
github.com/smartystreets/goconvey/web/server/parser.(*testParser).processLine(0xc200131900, 0x21901)
        /Users/tim/mlog/go/src/github.com/smartystreets/goconvey/web/server/parser/testParser.go:61 +0x24a
github.com/smartystreets/goconvey/web/server/parser.(*testParser).processLines(0xc200131900)
        /Users/tim/mlog/go/src/github.com/smartystreets/goconvey/web/server/parser/testParser.go:43 +0x6d
github.com/smartystreets/goconvey/web/server/parser.(*testParser).parseTestFunctionOutput(0xc200131900)
        /Users/tim/mlog/go/src/github.com/smartystreets/goconvey/web/server/parser/testParser.go:35 +0x32
github.com/smartystreets/goconvey/web/server/parser.parseTestOutput(0xc2003836c0, 0x3e9568)
        /Users/tim/mlog/go/src/github.com/smartystreets/goconvey/web/server/parser/testParser.go:23 +0x54
github.com/smartystreets/goconvey/web/server/parser.(*outputParser).parseEachTestFunction(0xc2001315a0)
        /Users/tim/mlog/go/src/github.com/smartystreets/goconvey/web/server/parser/packageParser.go:119 +0x74
github.com/smartystreets/goconvey/web/server/parser.(*outputParser).parse(0xc2001315a0)
        /Users/tim/mlog/go/src/github.com/smartystreets/goconvey/web/server/parser/packageParser.go:35 +0x33
github.com/smartystreets/goconvey/web/server/parser.ParsePackageResults(0xc2001d2d20, 0xc20017b000, 0x908)
        /Users/tim/mlog/go/src/github.com/smartystreets/goconvey/web/server/parser/packageParser.go:10 +0x47
github.com/smartystreets/goconvey/web/server/parser.(*Parser).Parse(0xc2000004e0, 0xc20012e500, 0x98, 0x98)
        /Users/tim/mlog/go/src/github.com/smartystreets/goconvey/web/server/parser/parser.go:15 +0x9f
github.com/smartystreets/goconvey/web/server/executor.(*Executor).parse(0xc200157500, 0xc20012e500, 0x98, 0x98, 0x0, ...)
        /Users/tim/mlog/go/src/github.com/smartystreets/goconvey/web/server/executor/executor.go:41 +0xfe
github.com/smartystreets/goconvey/web/server/executor.(*Executor).ExecuteTests(0xc200157500, 0xc20012e500, 0x98, 0x98, 0x0, ...)
        /Users/tim/mlog/go/src/github.com/smartystreets/goconvey/web/server/executor/executor.go:29 +0xb2
github.com/smartystreets/goconvey/web/server/contract.(*Monitor).executeTests(0xc20015b000)
        /Users/tim/mlog/go/src/github.com/smartystreets/goconvey/web/server/contract/monitor.go:34 +0x100
github.com/smartystreets/goconvey/web/server/contract.(*Monitor).Scan(0xc20015b000)
        /Users/tim/mlog/go/src/github.com/smartystreets/goconvey/web/server/contract/monitor.go:24 +0x46
github.com/smartystreets/goconvey/web/server/contract.(*Monitor).ScanForever(0xc20015b000)
        /Users/tim/mlog/go/src/github.com/smartystreets/goconvey/web/server/contract/monitor.go:18 +0xab
created by main.main
        /Users/tim/mlog/go/src/github.com/smartystreets/goconvey/goconvey.go:47 +0x134
```
