### PR TITLE
added command line setting to specify the path to the go binary. useful ...

### DIFF
--- a/goconvey.go
+++ b/goconvey.go
@@ -33,7 +33,7 @@ func init() {
 	flag.StringVar(&host, "host", "127.0.0.1", "The host at which to serve http.")
 	flag.DurationVar(&nap, "poll", quarterSecond, "The interval to wait between polling the file system for changes (default: 250ms).")
 	flag.IntVar(&packages, "packages", 10, "The number of packages to test in parallel. Higher == faster but more costly in terms of computing. (default: 10)")
-
+	flag.StringVar(&gobin, "gobin", "go", "The path to the 'go' binary (default: search on the PATH)")
 	log.SetOutput(os.Stdout)
 	log.SetFlags(log.LstdFlags | log.Lshortfile)
 }
@@ -88,7 +88,7 @@ func wireup() (*contract.Monitor, contract.Server) {
 	}
 
 	fs := system.NewFileSystem()
-	shell := system.NewShell()
+	shell := system.NewShell(gobin)
 
 	watcher := watch.NewWatcher(fs, shell)
 	watcher.Adjust(working)
@@ -113,6 +113,7 @@ func sleeper() {
 var (
 	port     int
 	host     string
+	gobin    string
 	nap      time.Duration
 	packages int
 )

--- a/web/server/system/shell.go
+++ b/web/server/system/shell.go
@@ -8,12 +8,13 @@ import (
 
 type Shell struct {
 	coverage string
+	gobin    string
 }
 
 func (self *Shell) GoTest(directory string) (output string, err error) {
-	output, err = self.execute(directory, "go", "test", "-i")
+	output, err = self.execute(directory, self.gobin, "test", "-i")
 	if err == nil {
-		output, err = self.execute(directory, "go", "test", "-v", "-timeout=-42s", self.coverage)
+		output, err = self.execute(directory, self.gobin, "test", "-v", "-timeout=-42s", self.coverage)
 	}
 	return
 }
@@ -37,8 +38,9 @@ func (self *Shell) Setenv(key, value string) error {
 	return nil
 }
 
-func NewShell() *Shell {
+func NewShell(gobin string) *Shell {
 	self := new(Shell)
+	self.gobin = gobin
 	if goVersion_1_2_orGreater() {
 		self.coverage = coverageFlag
 	}


### PR DESCRIPTION
...if you write appengine tests, here you must use "goapp test" instead of "go test". When starting "goconvey" there is a setting "-gobin" to specifiy the path. in my local installation i have the current version of the appengine SDK installed in `/home/usc/tools/appengine/go_appengine_current` and now i can run goconvey to use "goapp":

goconvey -gobin /home/usc/tools/appengine/go_appengine_current/goapp
