### PR TITLE
Fix unsafe string slicing in ShouldStartsWith/ShouldEndsWith.

### DIFF
--- a/assertions/strings.go
+++ b/assertions/strings.go
@@ -23,7 +23,11 @@ func ShouldStartWith(actual interface{}, expected ...interface{}) string {
 }
 func shouldStartWith(value, prefix string) string {
 	if !strings.HasPrefix(value, prefix) {
-		return serializer.serialize(prefix, value[:len(prefix)]+"...", fmt.Sprintf(shouldHaveStartedWith, value, prefix))
+		shortval := value
+		if len(shortval) > len(prefix) {
+			shortval = shortval[:len(prefix)] + "..."
+		}
+		return serializer.serialize(prefix, shortval, fmt.Sprintf(shouldHaveStartedWith, value, prefix))
 	}
 	return success
 }
@@ -73,7 +77,11 @@ func ShouldEndWith(actual interface{}, expected ...interface{}) string {
 }
 func shouldEndWith(value, suffix string) string {
 	if !strings.HasSuffix(value, suffix) {
-		return serializer.serialize(suffix, "..."+value[len(value)-len(suffix):], fmt.Sprintf(shouldHaveEndedWith, value, suffix))
+		shortval := value
+		if len(shortval) > len(suffix) {
+			shortval = "..." + shortval[len(shortval)-len(suffix):]
+		}
+		return serializer.serialize(suffix, shortval, fmt.Sprintf(shouldHaveEndedWith, value, suffix))
 	}
 	return success
 }

--- a/assertions/strings_test.go
+++ b/assertions/strings_test.go
@@ -9,6 +9,10 @@ func TestShouldStartWith(t *testing.T) {
 	fail(t, so("", ShouldStartWith, "asdf", "asdf"), "This assertion requires exactly 1 comparison values (you provided 2).")
 
 	pass(t, so("", ShouldStartWith, ""))
+	fail(t, so("", ShouldStartWith, "x"), "x||Expected '' to start with 'x' (but it didn't)!")
+	pass(t, so("abc", ShouldStartWith, "abc"))
+	fail(t, so("abc", ShouldStartWith, "abcd"), "abcd|abc|Expected 'abc' to start with 'abcd' (but it didn't)!")
+
 	pass(t, so("superman", ShouldStartWith, "super"))
 	fail(t, so("superman", ShouldStartWith, "bat"), "bat|sup...|Expected 'superman' to start with 'bat' (but it didn't)!")
 	fail(t, so("superman", ShouldStartWith, "man"), "man|sup...|Expected 'superman' to start with 'man' (but it didn't)!")
@@ -35,6 +39,10 @@ func TestShouldEndWith(t *testing.T) {
 	fail(t, so("", ShouldEndWith, "", ""), "This assertion requires exactly 1 comparison values (you provided 2).")
 
 	pass(t, so("", ShouldEndWith, ""))
+	fail(t, so("", ShouldEndWith, "z"), "z||Expected '' to end with 'z' (but it didn't)!")
+	pass(t, so("xyz", ShouldEndWith, "xyz"))
+	fail(t, so("xyz", ShouldEndWith, "wxyz"), "wxyz|xyz|Expected 'xyz' to end with 'wxyz' (but it didn't)!")
+
 	pass(t, so("superman", ShouldEndWith, "man"))
 	fail(t, so("superman", ShouldEndWith, "super"), "super|...erman|Expected 'superman' to end with 'super' (but it didn't)!")
 	fail(t, so("superman", ShouldEndWith, "blah"), "blah|...rman|Expected 'superman' to end with 'blah' (but it didn't)!")


### PR DESCRIPTION
This fixes a slice bounds panic whenever a shorter string is compared against a longer prefix/suffix.
