### PR TITLE
Explain go version requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Welcome to GoConvey, a yummy Go testing tool for gophers. Works with `go test`. 
 Installation
 ------------
 
+Make sure you are running  go version 1.2 
+
 	$ go get -t github.com/smartystreets/goconvey
 
 The `-t` flag above ensures that all test dependencies for goconvey are downloaded.


### PR DESCRIPTION
Lost whole day yesterday trying to run goconvey with go 1.1.1, it didn't work.
