### PR TITLE
Use custom URL Scheme in web UI to allow compatibility with any editor

### DIFF
--- a/web/client/index.html
+++ b/web/client/index.html
@@ -216,7 +216,7 @@
 									</td>
 									<td class="line">
 									{{if Line|more>0}}
-										<a href="subl://open/?url=file://{{File|url}}&line={{Line}}">Line {{Line}}</a>
+										<a href="goconvey://open/?url=file://{{File|url}}&line={{Line}}">Line {{Line}}</a>
 										{{/if}}
 									</td>
 								</tr>
@@ -260,7 +260,7 @@
 										<a href="#test-{{_id}}" class="block">{{if File|notempty}}{{File|relativePath}}{{else}}{{TestName}}{{/if}} <i class="fa fa-level-down"></i></a>
 									</td>
 									<td class="line">
-										{{if Line|more>0}}<a href="subl://open/?url=file://{{File|url}}&line={{Line}}">Line {{Line}}</a>{{/if}}
+										{{if Line|more>0}}<a href="goconvey://open/?url=file://{{File|url}}&line={{Line}}">Line {{Line}}</a>{{/if}}
 									</td>
 								</tr>
 								{{if Stories|empty}}
@@ -402,7 +402,7 @@
 					<div class="panic-shortcuts templated">
 						<b>Panics</b><hr>
 						{{.}}
-							<a href="subl://open/?url=file://{{File|url}}&line={{Line}}">{{if File}}{{File|relativePath}}{{else}}{{TestName}}{{/if}}{{if Line}}:{{Line}}{{/if}}</a>
+							<a href="goconvey://open/?url=file://{{File|url}}&line={{Line}}">{{if File}}{{File|relativePath}}{{else}}{{TestName}}{{/if}}{{if Line}}:{{Line}}{{/if}}</a>
 							<a href="#test-{{_id}}" class="goto" title="See in context"><i class="fa fa-level-down"></i></a><br>
 						{{/.}}
 					</div>
@@ -411,7 +411,7 @@
 					<div class="failure-shortcuts templated">
 						<b>Failures</b><hr>
 						{{.}}
-							<a href="subl://open/?url=file://{{File|url}}&line={{Line}}">{{if File}}{{File|relativePath}}{{else}}{{TestName}}{{/if}}{{if Line}}:{{Line}}{{/if}}</a>
+							<a href="goconvey://open/?url=file://{{File|url}}&line={{Line}}">{{if File}}{{File|relativePath}}{{else}}{{TestName}}{{/if}}{{if Line}}:{{Line}}{{/if}}</a>
 							<a href="#test-{{_id}}" class="goto"><i class="fa fa-level-down"></i></a><br>
 						{{/.}}
 					</div>


### PR DESCRIPTION
## Problem

Not everyone uses Sublime editor so the links to edit a failing test in Sublime aren't universally useful.

I would like to have a way to specify my editor (Mac Vim, etc).
## Solution

Allow the user to specify which editor (via the protocol) they wish to use.

For example:

`$ GOCONVEY_EDITOR_PROTOCOL="mvim" goconvey`
`$ EDITOR_PROTOCOL="subl" goconvey`

Or just export it in your `~/.bashrc` or something and be happy.
## Implementation
- I defaulted to Sublime in the event you don't specify anything.
- I "patch" in the `EditorProtocol` value to the context in the `render` function. This works in practice, but feels sort of dirty because we aren't being super explicit. The alternative would be to explicitly add `EditorProtocol` to the context before calling `render`. Let me know what you think.

This implementation doesn't try to be clever at all: ![image](http://i.imgur.com/oIl1M2H.png)
