### PR TITLE
Remove serif fonts from 'overall' bar

### DIFF
--- a/web/client/css/goconvey.css
+++ b/web/client/css/goconvey.css
@@ -192,7 +192,8 @@ a.link-fa.disabled {
 	float: left;
 	margin-right: .75em;
 	color: #FFF;
-	font: bold 80px 'Georgia', serif;
+	font-weight: bold;
+	font-size: 80px;
 	text-transform: uppercase;
 }
 
@@ -209,7 +210,7 @@ a.link-fa.disabled {
 
 .overall .summary {
 	float: left;
-	font: 18px/1.25em monospace;
+	font: 18px/1.25em "Lucida Console", Monaco, monospace;;
 	color: rgba(255, 255, 255, .85);
 	margin-top: .5em;
 }


### PR DESCRIPTION
The serif 'overall' bar really feels out-of-place with the sans-serif body.  In my opinion, going with the inherited font for the status and a sans-serif monospaced font for the summary improves the look.

![ok](https://f.cloud.github.com/assets/184976/2489805/2a13dc58-b179-11e3-9003-fc5b6263d5d9.png)
![fail](https://f.cloud.github.com/assets/184976/2489804/2a12b7a6-b179-11e3-952b-1a93cc49a7fa.png)
