### PR TITLE
Use return value of runtime.Stack to trim stack trace.

### DIFF
--- a/convey/reporting/reports.go
+++ b/convey/reporting/reports.go
@@ -139,17 +139,16 @@ func caller() (file string, line int) {
 	file, line, _ = gotest.ResolveExternalCaller()
 	return
 }
+
 func stackTrace() string {
 	buffer := make([]byte, 1024*64)
-	runtime.Stack(buffer, false)
-	formatted := strings.Trim(string(buffer), string([]byte{0}))
-	return removeInternalEntries(formatted)
+	n := runtime.Stack(buffer, false)
+	return removeInternalEntries(string(buffer[:n]))
 }
 func fullStackTrace() string {
 	buffer := make([]byte, 1024*64)
-	runtime.Stack(buffer, true)
-	formatted := strings.Trim(string(buffer), string([]byte{0}))
-	return removeInternalEntries(formatted)
+	n := runtime.Stack(buffer, true)
+	return removeInternalEntries(string(buffer[:n]))
 }
 func removeInternalEntries(stack string) string {
 	lines := strings.Split(stack, newline)


### PR DESCRIPTION
I have a package with about 300 assertions. This change reduces test time from 1.5s to 0.5s on my machine. It turns out scanning through a 64KB buffer on every assertion is expensive.

Is it really necessary for stack traces to be generated for success reports? The filtering of goconvey paths from each trace dominates cpu time if there's not much work being done between assertions.
