### PR TITLE
Unique closure variables per Convey invocation

### DIFF
--- a/convey/isolated_execution_test.go
+++ b/convey/isolated_execution_test.go
@@ -305,6 +305,71 @@ func TestIterativeConveys(t *testing.T) {
 	expectEqual(t, "0123456789", output)
 }
 
+func TestClosureVariables(t *testing.T) {
+	output := prepare()
+
+	i := 0
+
+	Convey("A", t, func() {
+		i = i + 1
+		j := i
+
+		output += "A" + strconv.Itoa(i) + " "
+
+		Convey("B", func() {
+			k := j
+			j = j + 1
+
+			output += "B" + strconv.Itoa(k) + " "
+
+			Convey("C", func() {
+				output += "C" + strconv.Itoa(k) + strconv.Itoa(j) + " "
+			})
+
+			Convey("D", func() {
+				output += "D" + strconv.Itoa(k) + strconv.Itoa(j) + " "
+			})
+		})
+
+		Convey("C", func() {
+			output += "C" + strconv.Itoa(j) + " "
+		})
+	})
+
+	output += "D" + strconv.Itoa(i) + " "
+
+	expectEqual(t, "A1 B1 C12 A2 B2 D23 A3 C3 D3 ", output)
+}
+
+func TestClosureVariablesWithReset(t *testing.T) {
+	output := prepare()
+
+	i := 0
+
+	Convey("A", t, func() {
+		i = i + 1
+		j := i
+
+		output += "A" + strconv.Itoa(i) + " "
+
+		Reset(func() {
+			output += "R" + strconv.Itoa(i) + strconv.Itoa(j) + " "
+		})
+
+		Convey("B", func() {
+			output += "B" + strconv.Itoa(j) + " "
+		})
+
+		Convey("C", func() {
+			output += "C" + strconv.Itoa(j) + " "
+		})
+	})
+
+	output += "D" + strconv.Itoa(i) + " "
+
+	expectEqual(t, "A1 B1 R11 A2 C2 R22 D2 ", output)
+}
+
 func prepare() string {
 	testReporter = newNilReporter()
 	return ""

--- a/convey/scope.go
+++ b/convey/scope.go
@@ -21,19 +21,27 @@ type scope struct {
 }
 
 func (parent *scope) adopt(child *scope) {
-	if parent.hasChild(child) {
-		return
+	i := parent.getChildIndex(child)
+
+	if i == -1 {
+		parent.children[child.name] = child
+		parent.birthOrder = append(parent.birthOrder, child)
+	} else {
+		/* We need to replace the action to retain the closed over variables from
+		   the specific invocation of the parent scope, enabling the enclosing
+		   parent scope to serve as a set-up for the child scope */
+		parent.birthOrder[i].action = child.action
 	}
-	parent.birthOrder = append(parent.birthOrder, child)
-	parent.children[child.name] = child
 }
-func (parent *scope) hasChild(child *scope) bool {
-	for _, ordered := range parent.birthOrder {
+
+func (parent *scope) getChildIndex(child *scope) int {
+	for i, ordered := range parent.birthOrder {
 		if ordered.name == child.name && ordered.title == child.title {
-			return true
+			return i
 		}
 	}
-	return false
+
+	return -1
 }
 
 func (self *scope) registerReset(action *action) {


### PR DESCRIPTION
Currently all tests require the test-writer to declare a variable outside the outermost `Convey`-block to be able to reinitialize the data for every nested test:

``` go
func TestNestingVar(t *testing.T) {
    j := 0

    var i int

    Convey("A", t, func() {
        j = j + 1
        i = j

        Convey("B", func() {
            So(i, ShouldEqual, 1)
        })

        Convey("C", func() {
            So(i, ShouldEqual, 2)
        })
    })
}
```

This pollutes the scope and also makes it slightly less intuitive for reasoning about what data is present in the nested `Convey`-blocks. And in the worst case the writer might forget to reset the data in this "test-global" variable before the following tests, creating a possibility for test failures to cascade due to shared state.

This pull request enables the tests to be written like this:

``` go
func TestNesting(t *testing.T) {
    j := 0

    Convey("A", t, func() {
        j = j + 1
        i := j

        Convey("B", func() {
            So(i, ShouldEqual, 1)
        })

        Convey("C", func() {
            So(i, ShouldEqual, 2)
        })
    })
}
```

With the `i` variable above being properly enclosed in the nested closures, so that `B` gets the `i` from the first invocation of `A` and `C` gets the second instance of the `i`.

The way this has been solved is that every time a nested `Convey`-block executes it replaces the nested actions, so that every new execution of `A` will update both `B` and `C` above. Thanks to the execution order it will use the correct closure.
