### PR TITLE
Added test for issue 197

### DIFF
--- a/convey/isolated_execution_test.go
+++ b/convey/isolated_execution_test.go
@@ -1,6 +1,7 @@
 package convey
 
 import (
+	"time"
 	"strconv"
 	"testing"
 )
@@ -456,6 +457,30 @@ func TestWrappedReset2(t *testing.T) {
 	})
 
 	expectEqual(t, "A B C R A D R ", output.output)
+}
+
+func TestInfiniteLoopWithTrailingFail(t *testing.T) {
+	done := make(chan int)
+
+	go func() {
+		Convey("This fails", t, func() {
+			Convey("and this is run", func() {
+				So(true, ShouldEqual, true)
+			})
+
+			/* And this prevents the whole block to be marked as run */
+			So(false, ShouldEqual, true)
+		})
+
+		done <- 1
+	}()
+
+	select {
+	case <-done:
+		return
+	case <-time.After(1 * time.Millisecond):
+		t.Fail()
+	}
 }
 
 func prepare() string {


### PR DESCRIPTION
Issue is #197, infinite loop caused by failing `So`-statement at the end of a `Convey`-block.

This pull-request should fail tests as long as pull-request #198 is not merged.
