### PR TITLE
Ensure that Reset on outermost block is called for every nested grandchild

### DIFF
--- a/convey/isolated_execution_test.go
+++ b/convey/isolated_execution_test.go
@@ -483,6 +483,44 @@ func TestInfiniteLoopWithTrailingFail(t *testing.T) {
 	}
 }
 
+func TestOutermostResetInvokedForGrandchildren(t *testing.T) {
+	output := prepare()
+
+	Convey("A", t, func() {
+		output += "A "
+
+		Reset(func() {
+			output += "rA "
+		})
+
+		Convey("B", func() {
+			output += "B "
+
+			Reset(func() {
+				output += "rB "
+			})
+
+			Convey("C", func() {
+				output += "C "
+
+				Reset(func() {
+					output += "rC "
+				})
+			})
+
+			Convey("D", func() {
+				output += "D "
+
+				Reset(func() {
+					output += "rD "
+				})
+			})
+		})
+	})
+
+	expectEqual(t, "A B C rC rB rA A B D rD rB rA ", output)
+}
+
 func prepare() string {
 	testReporter = newNilReporter()
 	return ""

--- a/convey/scope.go
+++ b/convey/scope.go
@@ -74,8 +74,9 @@ func (parent *scope) visitChild(runner *runner) {
 	child := parent.birthOrder[parent.child]
 	child.visit(runner)
 
+	parent.cleanup()
+
 	if child.visited() {
-		parent.cleanup()
 		parent.child++
 	}
 }


### PR DESCRIPTION
This test-structure failed to invoke the outermost reset while iterating the grandchildren of the main-block:

``` go
Convey("A", t, func() {
    Reset(func() {
        // This is skipped when done testing C,
        // it is only run after invoking A -> B -> D

        // Should be invoked after C, before second run of A
    })

    Convey("B", func() {
        Convey("C", func() {})
        Convey("D", func() {})
    })
})
```

Included test for this particular issue, and all tests pass.
