### PR TITLE
Implemented failure-mode settings per Convey-block

### DIFF
--- a/convey/discovery.go
+++ b/convey/discovery.go
@@ -28,15 +28,21 @@ func parseGoTest(items []interface{}) t {
 }
 func parseAction(items []interface{}, test t) *action {
 	var index = 1
+	var failure = FailureInherits
 	if test != nil {
 		index = 2
 	}
 
+	if mode, parsed := items[index].(FailureMode); parsed {
+		failure = mode
+		index += 1
+	}
+
 	if action, parsed := items[index].(func()); parsed {
-		return newAction(action)
+		return newAction(action, failure)
 	}
 	if items[index] == nil {
-		return newSkippedAction(skipReport)
+		return newSkippedAction(skipReport, failure)
 	}
 	panic(parseError)
 }
@@ -48,4 +54,4 @@ type t interface {
 	Fail()
 }
 
-const parseError = "You must provide a name (string), then a *testing.T (if in outermost scope), and then an action (func())."
+const parseError = "You must provide a name (string), then a *testing.T (if in outermost scope), an optional FailureMode, and then an action (func())."

--- a/convey/isolated_execution_test.go
+++ b/convey/isolated_execution_test.go
@@ -521,6 +521,206 @@ func TestOutermostResetInvokedForGrandchildren(t *testing.T) {
 	expectEqual(t, "A B C rC rB rA A B D rD rB rA ", output)
 }
 
+func TestFailureOption(t *testing.T) {
+	output := prepare()
+
+	Convey("A", t, FailureHalts, func() {
+		output += "A "
+		So(true, ShouldEqual, true)
+		output += "B "
+		So(false, ShouldEqual, true)
+		output += "C "
+	})
+
+	expectEqual(t, "A B ", output)
+}
+
+func TestFailureOption2(t *testing.T) {
+	output := prepare()
+
+	Convey("A", t, func() {
+		output += "A "
+		So(true, ShouldEqual, true)
+		output += "B "
+		So(false, ShouldEqual, true)
+		output += "C "
+	})
+
+	expectEqual(t, "A B ", output)
+}
+
+func TestFailureOption3(t *testing.T) {
+	output := prepare()
+
+	Convey("A", t, FailureContinues, func() {
+		output += "A "
+		So(true, ShouldEqual, true)
+		output += "B "
+		So(false, ShouldEqual, true)
+		output += "C "
+	})
+
+	expectEqual(t, "A B C ", output)
+}
+
+func TestFailureOptionInherit(t *testing.T) {
+	output := prepare()
+
+	Convey("A", t, FailureContinues, func() {
+		output += "A1 "
+		So(false, ShouldEqual, true)
+		output += "A2 "
+
+		Convey("B", func() {
+			output += "B1 "
+			So(true, ShouldEqual, true)
+			output += "B2 "
+			So(false, ShouldEqual, true)
+			output += "B3 "
+		})
+	})
+
+	expectEqual(t, "A1 A2 B1 B2 B3 ", output)
+}
+
+func TestFailureOptionInherit2(t *testing.T) {
+	output := prepare()
+
+	Convey("A", t, FailureHalts, func() {
+		output += "A1 "
+		So(false, ShouldEqual, true)
+		output += "A2 "
+
+		Convey("B", func() {
+			output += "A1 "
+			So(true, ShouldEqual, true)
+			output += "A2 "
+			So(false, ShouldEqual, true)
+			output += "A3 "
+		})
+	})
+
+	expectEqual(t, "A1 ", output)
+}
+
+func TestFailureOptionInherit3(t *testing.T) {
+	output := prepare()
+
+	Convey("A", t, FailureHalts, func() {
+		output += "A1 "
+		So(true, ShouldEqual, true)
+		output += "A2 "
+
+		Convey("B", func() {
+			output += "B1 "
+			So(true, ShouldEqual, true)
+			output += "B2 "
+			So(false, ShouldEqual, true)
+			output += "B3 "
+		})
+	})
+
+	expectEqual(t, "A1 A2 B1 B2 ", output)
+}
+
+func TestFailureOptionNestedOverride(t *testing.T) {
+	output := prepare()
+
+	Convey("A", t, FailureContinues, func() {
+		output += "A "
+		So(false, ShouldEqual, true)
+		output += "B "
+
+		Convey("C", FailureHalts, func() {
+			output += "C "
+			So(true, ShouldEqual, true)
+			output += "D "
+			So(false, ShouldEqual, true)
+			output += "E "
+		})
+	})
+
+	expectEqual(t, "A B C D ", output)
+}
+
+func TestFailureOptionNestedOverride2(t *testing.T) {
+	output := prepare()
+
+	Convey("A", t, FailureHalts, func() {
+		output += "A "
+		So(true, ShouldEqual, true)
+		output += "B "
+
+		Convey("C", FailureContinues, func() {
+			output += "C "
+			So(true, ShouldEqual, true)
+			output += "D "
+			So(false, ShouldEqual, true)
+			output += "E "
+		})
+	})
+
+	expectEqual(t, "A B C D E ", output)
+}
+
+func TestMultipleInvocationInheritance(t *testing.T) {
+	output := prepare()
+
+	Convey("A", t, FailureHalts, func() {
+		output += "A1 "
+		So(true, ShouldEqual, true)
+		output += "A2 "
+
+		Convey("B", FailureContinues, func() {
+			output += "B1 "
+			So(true, ShouldEqual, true)
+			output += "B2 "
+			So(false, ShouldEqual, true)
+			output += "B3 "
+		})
+
+		Convey("C", func() {
+			output += "C1 "
+			So(true, ShouldEqual, true)
+			output += "C2 "
+			So(false, ShouldEqual, true)
+			output += "C3 "
+		})
+	})
+
+	expectEqual(t, "A1 A2 B1 B2 B3 A1 A2 C1 C2 ", output)
+}
+
+func TestMultipleInvocationInheritance2(t *testing.T) {
+	output := prepare()
+
+	Convey("A", t, FailureContinues, func() {
+		output += "A1 "
+		So(true, ShouldEqual, true)
+		output += "A2 "
+		So(false, ShouldEqual, true)
+		output += "A3 "
+
+		Convey("B", FailureHalts, func() {
+			output += "B1 "
+			So(true, ShouldEqual, true)
+			output += "B2 "
+			So(false, ShouldEqual, true)
+			output += "B3 "
+		})
+
+		Convey("C", func() {
+			output += "C1 "
+			So(true, ShouldEqual, true)
+			output += "C2 "
+			So(false, ShouldEqual, true)
+			output += "C3 "
+		})
+	})
+
+	expectEqual(t, "A1 A2 A3 B1 B2 A1 A2 A3 C1 C2 C3 ", output)
+}
+
 func prepare() string {
 	testReporter = newNilReporter()
 	return ""

--- a/convey/registration.go
+++ b/convey/registration.go
@@ -34,22 +34,24 @@ func newRegistration(situation string, action *action, test t) *registration {
 ////////////////////////// action ///////////////////////
 
 type action struct {
-	wrapped func()
-	name    string
+	wrapped     func()
+	name        string
+	failureMode FailureMode
 }
 
 func (self *action) Invoke() {
 	self.wrapped()
 }
 
-func newAction(wrapped func()) *action {
+func newAction(wrapped func(), mode FailureMode) *action {
 	self := new(action)
 	self.name = functionName(wrapped)
 	self.wrapped = wrapped
+	self.failureMode = mode
 	return self
 }
 
-func newSkippedAction(wrapped func()) *action {
+func newSkippedAction(wrapped func(), mode FailureMode) *action {
 	self := new(action)
 
 	// The choice to use the filename and line number as the action name
@@ -57,6 +59,7 @@ func newSkippedAction(wrapped func()) *action {
 	// in a determinist way to the action itself.
 	self.name = gotest.FormatExternalFileAndLine()
 	self.wrapped = wrapped
+	self.failureMode = mode
 	return self
 }
 

--- a/convey/scope.go
+++ b/convey/scope.go
@@ -56,6 +56,15 @@ func (parent *scope) visit(runner *runner) {
 	runner.active = parent
 	defer parent.exit()
 
+	// Set and reset failure mode
+	oldFailure := runner.failureMode
+	if parent.action.failureMode != FailureInherits {
+		runner.failureMode = parent.action.failureMode
+	}
+	defer func() {
+		runner.failureMode = oldFailure
+	}()
+
 	parent.enter()
 	parent.action.Invoke()
 	parent.visitChildren(runner)

--- a/convey/story_conventions_test.go
+++ b/convey/story_conventions_test.go
@@ -69,7 +69,7 @@ func TestExtraReferencePanics(t *testing.T) {
 func TestParseRegistrationMissingRequiredElements(t *testing.T) {
 	defer func() {
 		if r := recover(); r != nil {
-			if r != "You must provide a name (string), then a *testing.T (if in outermost scope), and then an action (func())." {
+			if r != "You must provide a name (string), then a *testing.T (if in outermost scope), an optional FailureMode, and then an action (func())." {
 				t.Errorf("Incorrect panic message.")
 			}
 		}


### PR DESCRIPTION
This allows tests to optionally specify on a block-level if they
want their failing So()-assertions to block further execution of
the test arm or if they want failing So()-assertions to allow the
test-arm to proceed.

Top-level blocks default to halting execution on a So()-assertion
failure and every block inherits from its parent-block to avoid
repetition.
