### PR TITLE
Fix coverage not running

### DIFF
--- a/web/server/system/shell.go
+++ b/web/server/system/shell.go
@@ -41,7 +41,6 @@ func (self *Shell) tryRunWithCoverage(directory, packageName string) (output str
 	output, err = self.runWithCoverage(directory, packageName, profileName+".txt")
 
 	if err != nil && !coverageStatementRE.MatchString(output) {
-		self.coverage = false
 		output, err = self.runWithoutCoverage(directory, packageName)
 	} else if self.coverage {
 		self.generateCoverageReports(directory, profileName+".txt", profileName+".html")


### PR DESCRIPTION
Issue smartystreets/goconvey/#242

Hopefully a better way to determine if cover tool is installed.  Coverage was not being run if go test returned with exit status of 1.
