### PR TITLE
Added method to kill long running or hung tests

### DIFF
--- a/goconvey.go
+++ b/goconvey.go
@@ -109,6 +109,7 @@ func serveAjaxMethods(server contract.Server) {
 	http.HandleFunc("/status", server.Status)
 	http.HandleFunc("/status/poll", server.LongPollStatus)
 	http.HandleFunc("/pause", server.TogglePause)
+	http.HandleFunc("/kill", server.Kill)
 }
 
 func activateServer() {

--- a/web/client/index.html
+++ b/web/client/index.html
@@ -44,6 +44,7 @@
 					<ul class="float-right" id="control-buttons">
 						<li class="fa fa-pause" id="play-pause" title="Play/pause tests"></li>
 						<li class="fa fa-refresh" id="run-tests" title="Run tests"></li>
+						<li class="fa fa-times disabled" id="stop-tests" title="Stop tests"></li>
 						<li class="fa fa-history" id="show-history" title="Test history"></li>
 						<li class="fa fa-bell-o" id="toggle-notif" title="Toggle notifications"></li>
 						<li class="fa fa-cog" id="show-settings" title="Settings"></li>

--- a/web/client/resources/js/goconvey.js
+++ b/web/client/resources/js/goconvey.js
@@ -62,6 +62,7 @@ function initPoller()
 		convey.status = "starting";
 		showServerDown("Server starting");
 		$('#run-tests').addClass('spin-slowly disabled');
+		$('#stop-tests').removeClass('disabled');
 	});
 
 	$(convey.poller).on('pollsuccess', function(event, data)
@@ -72,11 +73,15 @@ function initPoller()
 		// These two if statements determine if the server is now busy
 		// (and wasn't before) or is not busy (regardless of whether it was before)
 		if ((!convey.status || convey.status == "idle")
-				&& data.status && data.status != "idle")
+				&& data.status && data.status != "idle") 
+		{
 			$('#run-tests').addClass('spin-slowly disabled');
+			$('#stop-tests').removeClass('disabled');
+		}
 		else if (convey.status != "idle" && data.status == "idle")
 		{
 			$('#run-tests').removeClass('spin-slowly disabled');
+			$('#stop-tests').addClass('disabled');
 		}
 
 		switch (data.status)
@@ -195,6 +200,15 @@ function wireup()
 			return;
 		log("Test run invoked from web UI");
 		$.get("/execute");
+	});
+
+	$('#stop-tests').click(function()
+	{
+		var self = $(this);
+		if (self.hasClass('disabled'))
+			return;
+		log("Test run killed from web UI")
+		$.get("/kill")
 	});
 
 	$('#play-pause').click(function()
@@ -374,6 +388,9 @@ function wireup()
 				break;
 			case 82:		// r
 				$('#run-tests').click();
+				break;
+			case 83:
+				$('#stop-tests').click();
 				break;
 			case 78:		// n
 				$('#toggle-notif').click();

--- a/web/server/api/server.go
+++ b/web/server/api/server.go
@@ -149,6 +149,14 @@ func (self *HTTPServer) TogglePause(response http.ResponseWriter, request *http.
 	fmt.Fprint(response, self.paused) // we could write out whatever helps keep the UI honest...
 }
 
+func (self *HTTPServer) Kill(response http.ResponseWriter, request *http.Request) {
+	go self.kill()
+}
+
+func (self *HTTPServer) kill() {
+	self.executor.KillRunningTests()
+}
+
 func NewHTTPServer(
 	root string,
 	watcher chan messaging.WatcherCommand,

--- a/web/server/api/server_test.go
+++ b/web/server/api/server_test.go
@@ -465,6 +465,10 @@ func (self *FakeExecutor) ExecuteTests(watched []*contract.Package) *contract.Co
 	return output
 }
 
+func (self *FakeExecutor) KillRunningTests() {
+	//noop
+}
+
 func newFakeExecutor(status string, statusUpdate chan chan string) *FakeExecutor {
 	self := new(FakeExecutor)
 	self.status = status

--- a/web/server/contract/contracts.go
+++ b/web/server/contract/contracts.go
@@ -13,15 +13,18 @@ type (
 		Results(writer http.ResponseWriter, request *http.Request)
 		Execute(writer http.ResponseWriter, request *http.Request)
 		TogglePause(writer http.ResponseWriter, request *http.Request)
+		Kill(writer http.ResponseWriter, request *http.Request)
 	}
 
 	Executor interface {
 		ExecuteTests([]*Package) *CompleteOutput
 		Status() string
 		ClearStatusFlag() bool
+		KillRunningTests()
 	}
 
 	Shell interface {
 		GoTest(directory, packageName string, arguments []string) (output string, err error)
+		AbortGoTest() error
 	}
 )

--- a/web/server/executor/contract.go
+++ b/web/server/executor/contract.go
@@ -9,4 +9,5 @@ type Parser interface {
 type Tester interface {
 	SetBatchSize(batchSize int)
 	TestAll(folders []*contract.Package)
+	KillRunningTests()
 }

--- a/web/server/executor/executor.go
+++ b/web/server/executor/executor.go
@@ -37,6 +37,11 @@ func (self *Executor) ExecuteTests(folders []*contract.Package) *contract.Comple
 	return result
 }
 
+func (self *Executor) KillRunningTests() {
+	log.Print("Kill running tests")
+	self.tester.KillRunningTests()
+}
+
 func (self *Executor) execute(folders []*contract.Package) {
 	self.setStatus(Executing)
 	self.tester.TestAll(folders)

--- a/web/server/executor/executor_test.go
+++ b/web/server/executor/executor_test.go
@@ -130,6 +130,10 @@ func (self *FakeTester) addDelay(nap time.Duration) {
 	self.nap = nap
 }
 
+func (self *FakeTester) KillRunningTests() {
+	//noop
+}
+
 func newFakeTester() *FakeTester {
 	self := new(FakeTester)
 	zero, _ := time.ParseDuration("0")

--- a/web/server/executor/tester.go
+++ b/web/server/executor/tester.go
@@ -26,6 +26,11 @@ func (self *ConcurrentTester) TestAll(folders []*contract.Package) {
 	return
 }
 
+func (self *ConcurrentTester) KillRunningTests() {
+	log.Print("Killing executing tests")
+	self.shell.AbortGoTest()
+}
+
 func (self *ConcurrentTester) executeSynchronously(folders []*contract.Package) {
 	for _, folder := range folders {
 		packageName := strings.Replace(folder.Name, "\\", "/", -1)

--- a/web/server/executor/tester_test.go
+++ b/web/server/executor/tester_test.go
@@ -219,6 +219,10 @@ func (self *TimedShell) GoTest(directory, packageName string, arguments []string
 	return
 }
 
+func (self *TimedShell) AbortGoTest() error {
+	return self.err
+}
+
 func (self *TimedShell) composeCommand(commandText string) *ShellCommand {
 	start := time.Now()
 	time.Sleep(nap)

--- a/web/server/system/integration_testing/hang/.gitignore
+++ b/web/server/system/integration_testing/hang/.gitignore
@@ -1,0 +1,2 @@
+github.com-smartystreets-goconvey-*.html
+github.com-smartystreets-goconvey-*.txt

--- a/web/server/system/integration_testing/hang/hang.go
+++ b/web/server/system/integration_testing/hang/hang.go
@@ -1,0 +1,4 @@
+// This file's only purpose is to provide a realistic
+// environment from which to run hanging tests
+// against the system commands to kill.
+package hang

--- a/web/server/system/integration_testing/hang/hang.goconvey
+++ b/web/server/system/integration_testing/hang/hang.goconvey
@@ -1,0 +1,7 @@
+IGNORE
+-short
+-run=TestStuff
+
+// This file's only purpose is to provide a realistic
+// environment from which to run hanging tests
+// against the system commands to kill.

--- a/web/server/system/integration_testing/hang/hang_test.go
+++ b/web/server/system/integration_testing/hang/hang_test.go
@@ -1,0 +1,25 @@
+// This file's only purpose is to provide a realistic
+// environment from which to run hanging tests
+// against the system commands to kill.
+package hang
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestStuff(t *testing.T) {
+	if testing.Short() {
+		return
+	}
+
+	fmt.Println("Hanging...if this isn't killed shortly, there's a bug in GoConvey's command.kill")
+
+	for {
+
+	}
+
+	blah := make(chan string)
+	blah <- "hang!"
+
+}

--- a/web/server/system/shell_integration_test.go
+++ b/web/server/system/shell_integration_test.go
@@ -2,11 +2,12 @@ package system
 
 import (
 	"log"
+	"net/http"
 	"path/filepath"
 	"runtime"
 	"strings"
-
 	"testing"
+	"time"
 )
 
 func TestShellIntegration(t *testing.T) {
@@ -29,5 +30,56 @@ func TestShellIntegration(t *testing.T) {
 	}
 	if err != nil {
 		t.Error("Test run resulted in the following error:", err)
+	}
+}
+
+func TestShellHangIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping potentially long-running integration test...")
+		return
+	}
+
+	go func() {
+		log.Println(http.ListenAndServe("localhost:6060", nil))
+	}()
+
+	log.SetFlags(log.LstdFlags | log.Lshortfile | log.Lmicroseconds)
+
+	_, filename, _, _ := runtime.Caller(0)
+	directory := filepath.Join(filepath.Dir(filename), "integration_testing", "hang")
+	packageName := "github.com/smartystreets/goconvey/web/server/system/integration_testing/hang"
+
+	shell := NewShell("go", "", true)
+
+	const waitSeconds = 3
+	startTime := time.Now()
+	go func() {
+		// wait for 5 seconds, after that kill the process
+		timer := time.NewTimer(waitSeconds * time.Second)
+		<-timer.C
+		log.Print("abort go test!")
+		err := shell.AbortGoTest()
+		if err != nil {
+			t.Error("Test run abort resulted in error:", err)
+		}
+	}()
+
+	log.Print("start go test!")
+	//this method will hang...
+	output, err := shell.GoTest(directory, packageName, []string{})
+	stopTime := time.Now()
+	log.Print("go test returned")
+	// confirm duration is between 5 and 6 seconds
+	dur := stopTime.Sub(startTime)
+	if dur < (waitSeconds*time.Second) || dur > ((waitSeconds+1)*time.Second) {
+		t.Errorf("Expected %v second delay, was %s instead", waitSeconds, dur)
+	}
+
+	if !strings.Contains(output, "Hanging...") {
+		t.Errorf("Unexpected output from test run: [%s]", output)
+	}
+
+	if err == nil || err.Error() != "exit status 2" {
+		t.Errorf("Test run should have resulted in exit code error, was [%s] instead", err)
 	}
 }

--- a/web/server/system/shell_test.go
+++ b/web/server/system/shell_test.go
@@ -9,13 +9,13 @@ import (
 
 func TestShellCommandComposition(t *testing.T) {
 	var (
-		buildFailed      = Command{Error: errors.New("BUILD FAILURE!")}
-		buildSucceeded   = Command{Output: "ok"}
-		goConvey         = Command{Output: "[fmt github.com/smartystreets/goconvey/convey net/http net/http/httptest path runtime strconv strings testing time]"}
-		noGoConvey       = Command{Output: "[fmt net/http net/http/httptest path runtime strconv strings testing time]"}
-		noCoveragePassed = Command{Output: "PASS\nok  	github.com/smartystreets/goconvey/examples	0.012s"}
-		coveragePassed   = Command{Output: "PASS\ncoverage: 100.0% of statements\nok  	github.com/smartystreets/goconvey/examples	0.012s"}
-		coverageFailed   = Command{
+		buildFailed      = &Command{Error: errors.New("BUILD FAILURE!")}
+		buildSucceeded   = &Command{Output: "ok"}
+		goConvey         = &Command{Output: "[fmt github.com/smartystreets/goconvey/convey net/http net/http/httptest path runtime strconv strings testing time]"}
+		noGoConvey       = &Command{Output: "[fmt net/http net/http/httptest path runtime strconv strings testing time]"}
+		noCoveragePassed = &Command{Output: "PASS\nok  	github.com/smartystreets/goconvey/examples	0.012s"}
+		coveragePassed   = &Command{Output: "PASS\ncoverage: 100.0% of statements\nok  	github.com/smartystreets/goconvey/examples	0.012s"}
+		coverageFailed   = &Command{
 			Error: errors.New("Tests bombed!"),
 			Output: "--- FAIL: TestIntegerManipulation (0.00 seconds)\nFAIL\ncoverage: 100.0% of statements\nexit status 1\nFAIL	github.com/smartystreets/goconvey/examples	0.013s",
 		}
@@ -47,7 +47,7 @@ func TestShellCommandComposition(t *testing.T) {
 			result := runWithCoverage(buildSucceeded, goConvey, yesCoverage, "reportsPath", "/directory", "go", []string{"-arg1", "-arg2"})
 
 			Convey("The returned command should be well formed (and include the -json flag)", func() {
-				So(result, ShouldResemble, Command{
+				So(result, ShouldResemble, &Command{
 					directory:  "/directory",
 					executable: "go",
 					arguments:  []string{"test", "-v", "-coverprofile=reportsPath", "-covermode=set", "-json", "-arg1", "-arg2"},
@@ -59,7 +59,7 @@ func TestShellCommandComposition(t *testing.T) {
 			result := runWithCoverage(buildSucceeded, noGoConvey, yesCoverage, "reportsPath", "/directory", "go", []string{"-arg1", "-arg2"})
 
 			Convey("The returned command should be well formed (and NOT include the -json flag)", func() {
-				So(result, ShouldResemble, Command{
+				So(result, ShouldResemble, &Command{
 					directory:  "/directory",
 					executable: "go",
 					arguments:  []string{"test", "-v", "-coverprofile=reportsPath", "-covermode=set", "-arg1", "-arg2"},
@@ -71,7 +71,7 @@ func TestShellCommandComposition(t *testing.T) {
 			result := runWithCoverage(buildSucceeded, noGoConvey, yesCoverage, "reportsPath", "/directory", "go", []string{"-covermode=atomic"})
 
 			Convey("The returned command should allow the alternate value", func() {
-				So(result, ShouldResemble, Command{
+				So(result, ShouldResemble, &Command{
 					directory:  "/directory",
 					executable: "go",
 					arguments:  []string{"test", "-v", "-coverprofile=reportsPath", "-covermode=atomic"},
@@ -98,7 +98,7 @@ func TestShellCommandComposition(t *testing.T) {
 		})
 
 		Convey("And the build failed earlier", func() {
-			result := runWithoutCoverage(buildFailed, Command{}, goConvey, "/directory", "go", []string{"-arg1", "-arg2"})
+			result := runWithoutCoverage(buildFailed, &Command{}, goConvey, "/directory", "go", []string{"-arg1", "-arg2"})
 
 			Convey("Then no action should be taken", func() {
 				So(result, ShouldResemble, buildFailed)
@@ -109,7 +109,7 @@ func TestShellCommandComposition(t *testing.T) {
 			result := runWithoutCoverage(buildSucceeded, buildSucceeded, goConvey, "/directory", "go", []string{"-arg1", "-arg2"})
 
 			Convey("Then the returned command should be well formed (and include the -json flag)", func() {
-				So(result, ShouldResemble, Command{
+				So(result, ShouldResemble, &Command{
 					directory:  "/directory",
 					executable: "go",
 					arguments:  []string{"test", "-v", "-json", "-arg1", "-arg2"},
@@ -121,7 +121,7 @@ func TestShellCommandComposition(t *testing.T) {
 			result := runWithoutCoverage(buildSucceeded, noCoveragePassed, noGoConvey, "/directory", "go", []string{"-arg1", "-arg2"})
 
 			Convey("Then the returned command should be well formed (and NOT include the -json flag)", func() {
-				So(result, ShouldResemble, Command{
+				So(result, ShouldResemble, &Command{
 					directory:  "/directory",
 					executable: "go",
 					arguments:  []string{"test", "-v", "-arg1", "-arg2"},
@@ -151,7 +151,7 @@ func TestShellCommandComposition(t *testing.T) {
 			result := generateReports(coveragePassed, yesCoverage, "/directory", "go", "reportData", "reportHTML")
 
 			Convey("Then the resulting command should be well-formed", func() {
-				So(result, ShouldResemble, Command{
+				So(result, ShouldResemble, &Command{
 					directory:  "/directory",
 					executable: "go",
 					arguments:  []string{"tool", "cover", "-html=reportData", "-o", "reportHTML"},


### PR DESCRIPTION
Add a new "stop" button to the UI that can cleanly kill test executions that are hung or overly long.

I could use some advice on changing the shell.Command struct to being conceptually mutable so I could snag references to the "currently running" command.  I'm open to suggestions for cleaner/clearer ways to do this.
