### PR TITLE
Attempts to address #229, which exposes a need for a server-side field t...

### DIFF
--- a/web/client/resources/js/goconvey.js
+++ b/web/client/resources/js/goconvey.js
@@ -588,7 +588,10 @@ function process(data, status, jqxhr)
 			test._pkgid = pkg._id;
 			test._pkg = pkg.PackageName;
 
-			if (test.Stories.length == 0)
+			if (test.Stories.length == 0) 
+			// Note to Matt: Really, what we need is another server-side 
+			// field to identify the usage of the convey package (this 
+			// condition doesn't hold up in certain edge cases). --Mike
 			{
 				// Here we've got ourselves a classic Go test,
 				// not a GoConvey test that has stories and assertions
@@ -700,6 +703,21 @@ function process(data, status, jqxhr)
 				pkg._failed++;
 				test._failed++;
 				current().assertions.failed.push(test);
+			}
+
+			if (test.Error && test.Stories.length > 0)
+			{
+				// Another edge case: Developer wrote a valid convey(...) suite, then 
+				// in the same test function, wrote an invalid convey(...) suite
+				// (maybe the `t` was forgotton or repeated). So we have stories,
+				// but we also have an error.
+				
+				current().assertions.failed = [] // This gets rid of the "failure" section containing "???"
+
+				test._status = convey.statuses.panic;
+				pkg._panicked++;
+				test._panicked++;
+				current().assertions.panicked.push(test);
 			}
 		}
 	}

--- a/web/server/parser/package_parser_go1.2_test.go
+++ b/web/server/parser/package_parser_go1.2_test.go
@@ -114,6 +114,8 @@ func TestParsePacakge_WithExampleFunctions_ReturnsPackageResult(t *testing.T) {
 	assertEqual(t, expectedExampleFunctions, *actual)
 }
 
+////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 func assertEqual(t *testing.T, expected, actual interface{}) {
 	a, _ := json.Marshal(expected)
 	b, _ := json.Marshal(actual)
@@ -121,6 +123,8 @@ func assertEqual(t *testing.T, expected, actual interface{}) {
 		t.Errorf(failureTemplate, string(a), string(b))
 	}
 }
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 const failureTemplate = "Comparison failed:\n  Expected: %v\n    Actual: %v\n"
 

--- a/web/server/parser/testParser.go
+++ b/web/server/parser/testParser.go
@@ -3,6 +3,7 @@ package parser
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 	"strconv"
 	"strings"
 
@@ -88,7 +89,7 @@ func (self *testParser) deserializeJson() {
 	var scopes []reporting.ScopeResult
 	err := json.Unmarshal(formatted, &scopes)
 	if err != nil {
-		panic(fmt.Sprintf(bugReportRequest, err, formatted))
+		log.Fatalf(bugReportRequest, err, formatted)
 	}
 	self.test.Stories = scopes
 }


### PR DESCRIPTION
...o indicate whether the convey package was successfully used (at least initially) within the given test function.