### PR TITLE
Fix #4 by introducing optional test randomization

### DIFF
--- a/convey/context.go
+++ b/convey/context.go
@@ -2,6 +2,7 @@ package convey
 
 import (
 	"fmt"
+	"sort"
 
 	"github.com/jtolds/gls"
 	"github.com/smartystreets/goconvey/convey/reporting"
@@ -68,6 +69,7 @@ func mustGetCurrentContext() *context {
 // This implements the `C` interface.
 type context struct {
 	reporter reporting.Reporter
+	picker   picker
 
 	children map[string]*context
 
@@ -91,9 +93,10 @@ func rootConvey(items ...interface{}) {
 		conveyPanic(missingGoTest)
 	}
 
-	expectChildRun := true
+	var expectChildRun bool
 	ctx := &context{
 		reporter: buildReporter(),
+		picker:   newPicker(),
 
 		children: make(map[string]*context),
 
@@ -106,9 +109,15 @@ func rootConvey(items ...interface{}) {
 		ctx.reporter.BeginStory(reporting.NewStoryReport(entry.Test))
 		defer ctx.reporter.EndStory()
 
-		for ctx.shouldVisit() {
+		ranOnce := false
+		// if we're not randomizing, we can start running children right away
+		if !randomizeTests {
+			expectChildRun = true
+		}
+		for !ranOnce || ctx.shouldVisit() {
 			ctx.conveyInner(entry.Situation, entry.Func)
 			expectChildRun = true
+			ranOnce = true
 		}
 	})
 }
@@ -147,6 +156,7 @@ func (ctx *context) Convey(items ...interface{}) {
 		}
 		inner_ctx = &context{
 			reporter: ctx.reporter,
+			picker:   ctx.picker.New(),
 
 			children: make(map[string]*context),
 
@@ -156,9 +166,13 @@ func (ctx *context) Convey(items ...interface{}) {
 			failureMode: ctx.failureMode.combine(entry.FailMode),
 		}
 		ctx.children[entry.Situation] = inner_ctx
+
+		if randomizeTests {
+			*ctx.expectChildRun = false
+		}
 	}
 
-	if inner_ctx.shouldVisit() {
+	if inner_ctx.shouldVisit() && ctx.picker.Pick(entry.Situation) {
 		ctxMgr.SetValues(gls.Values{nodeKey: inner_ctx}, func() {
 			inner_ctx.conveyInner(entry.Situation, entry.Func)
 		})
@@ -210,6 +224,17 @@ func (c *context) shouldVisit() bool {
 // function body. At this point, Convey or RootConvey has decided that this
 // function should actually run.
 func (ctx *context) conveyInner(situation string, f func(C)) {
+	if ctx.executedOnce {
+		choices := []string{}
+		for k, v := range ctx.children {
+			if !v.complete {
+				choices = append(choices, k)
+			}
+		}
+		sort.Strings(choices)
+		ctx.picker.Enter(choices)
+	}
+
 	// Record/Reset state for next time.
 	defer func() {
 		ctx.executedOnce = true

--- a/convey/context.go
+++ b/convey/context.go
@@ -95,7 +95,7 @@ func rootConvey(items ...interface{}) {
 
 	var expectChildRun bool
 	ctx := &context{
-		reporter: buildReporter(),
+		reporter: buildReporter(entry.Test, getSeed()),
 		picker:   newPicker(),
 
 		children: make(map[string]*context),
@@ -106,8 +106,7 @@ func rootConvey(items ...interface{}) {
 		failureMode: defaultFailureMode.combine(entry.FailMode),
 	}
 	ctxMgr.SetValues(gls.Values{nodeKey: ctx}, func() {
-		ctx.reporter.BeginStory(reporting.NewStoryReport(entry.Test))
-		defer ctx.reporter.EndStory()
+		defer ctx.reporter.Close()
 
 		ranOnce := false
 		// if we're not randomizing, we can start running children right away
@@ -197,18 +196,15 @@ func (ctx *context) Reset(action func()) {
 }
 
 func (ctx *context) Print(items ...interface{}) (int, error) {
-	fmt.Fprint(ctx.reporter, items...)
-	return fmt.Print(items...)
+	return fmt.Fprint(ctx.reporter, items...)
 }
 
 func (ctx *context) Println(items ...interface{}) (int, error) {
-	fmt.Fprintln(ctx.reporter, items...)
-	return fmt.Println(items...)
+	return fmt.Fprintln(ctx.reporter, items...)
 }
 
 func (ctx *context) Printf(format string, items ...interface{}) (int, error) {
-	fmt.Fprintf(ctx.reporter, format, items...)
-	return fmt.Printf(format, items...)
+	return fmt.Fprintf(ctx.reporter, format, items...)
 }
 
 //////////////////////////////////// Private ////////////////////////////////////

--- a/convey/gotest/utils.go
+++ b/convey/gotest/utils.go
@@ -4,32 +4,22 @@
 package gotest
 
 import (
-	"fmt"
 	"runtime"
 	"strings"
 )
 
-func FormatExternalFileAndLine() string {
-	file, line, _ := ResolveExternalCaller()
-	if line == -1 {
-		return "<unknown caller!>" // panic?
-	}
-	return fmt.Sprintf("%s:%d", file, line)
-}
-
-func ResolveExternalCaller() (file string, line int, name string) {
-	var caller_id uintptr
+func ResolveExternalCaller() (string, int) {
 	callers := runtime.Callers(0, callStack)
 
 	for x := 0; x < callers; x++ {
-		caller_id, file, line, _ = runtime.Caller(x)
+		_, file, line, _ := runtime.Caller(x)
 		if strings.HasSuffix(file, "_test.go") {
-			name = runtime.FuncForPC(caller_id).Name()
-			return
+			return file, line
 		}
 	}
-	file, line, name = "<unkown file>", -1, "<unknown name>"
-	return // panic?
+
+	// panic?
+	return "<unkown file>", -1
 }
 
 const maxStackDepth = 100 // This had better be enough...

--- a/convey/isolated_execution_test.go
+++ b/convey/isolated_execution_test.go
@@ -753,6 +753,41 @@ func TestMultipleInvocationInheritance2(t *testing.T) {
 	expectEqual(t, "A1 A2 A3 B1 B2 A1 A2 A3 C1 C2 C3 ", output)
 }
 
+func TestRandomizedExecution(t *testing.T) {
+	randomizeTests = true
+	defer func() { randomizeTests = false }()
+
+	tests := map[int64]string{
+		1:  " A AD AC AB ABY ABX",
+		15: " A AB ABX AD AC ABY",
+	}
+
+	for seed, expect := range tests {
+		randomSeed = seed
+		output := prepare()
+
+		Convey("A", t, func() {
+			output += " A"
+
+			Convey("B", func() {
+				output += "B"
+
+				Convey("X", func() {
+					output += "X"
+				})
+
+				Convey("Y", func() {
+					output += "Y"
+				})
+			})
+			Convey("C", func() { output += "C" })
+			Convey("D", func() { output += "D" })
+		})
+
+		expectEqualCtx(t, expect, output, "seed %d", seed)
+	}
+}
+
 func TestSetDefaultFailureMode(t *testing.T) {
 	output := prepare()
 

--- a/convey/isolated_execution_test.go
+++ b/convey/isolated_execution_test.go
@@ -754,16 +754,19 @@ func TestMultipleInvocationInheritance2(t *testing.T) {
 }
 
 func TestRandomizedExecution(t *testing.T) {
-	randomizeTests = true
 	defer func() { randomizeTests = false }()
 
 	tests := map[int64]string{
+		0:  " ABX ABY AC AD", // non-randomized
 		1:  " A AD AC AB ABY ABX",
 		15: " A AB ABX AD AC ABY",
 	}
 
 	for seed, expect := range tests {
 		randomSeed = seed
+		if randomSeed != 0 {
+			randomizeTests = true
+		}
 		output := prepare()
 
 		Convey("A", t, func() {

--- a/convey/nilReporter.go
+++ b/convey/nilReporter.go
@@ -6,10 +6,9 @@ import (
 
 type nilReporter struct{}
 
-func (self *nilReporter) BeginStory(story *reporting.StoryReport)  {}
 func (self *nilReporter) Enter(scope *reporting.ScopeReport)       {}
 func (self *nilReporter) Report(report *reporting.AssertionResult) {}
 func (self *nilReporter) Exit()                                    {}
-func (self *nilReporter) EndStory()                                {}
+func (self *nilReporter) Close()                                   {}
 func (self *nilReporter) Write(p []byte) (int, error)              { return len(p), nil }
 func newNilReporter() *nilReporter                                 { return &nilReporter{} }

--- a/convey/reporting/dot.go
+++ b/convey/reporting/dot.go
@@ -4,8 +4,6 @@ import "fmt"
 
 type dot struct{ out *Printer }
 
-func (self *dot) BeginStory(story *StoryReport) {}
-
 func (self *dot) Enter(scope *ScopeReport) {}
 
 func (self *dot) Report(report *AssertionResult) {
@@ -27,13 +25,22 @@ func (self *dot) Report(report *AssertionResult) {
 
 func (self *dot) Exit() {}
 
-func (self *dot) EndStory() {}
+func (self *dot) Close() {}
 
 func (self *dot) Write(content []byte) (written int, err error) {
 	return len(content), nil // no-op
 }
 
-func NewDotReporter(out *Printer) *dot {
+func NewDotReporter(out *Printer, seed int64) *dot {
+	if seed != 0 {
+		out.Insert(whiteColor)
+		out.Suite("Random Seed")
+		out.Statement(seed)
+		out.Exit()
+		out.Insert(resetColor)
+		out.Insert("\n")
+	}
+
 	self := new(dot)
 	self.out = out
 	return self

--- a/convey/reporting/dot_test.go
+++ b/convey/reporting/dot_test.go
@@ -9,7 +9,7 @@ func TestDotReporterAssertionPrinting(t *testing.T) {
 	monochrome()
 	file := newMemoryFile()
 	printer := NewPrinter(file)
-	reporter := NewDotReporter(printer)
+	reporter := NewDotReporter(printer, 0)
 
 	reporter.Report(NewSuccessReport())
 	reporter.Report(NewFailureReport("failed"))
@@ -27,7 +27,7 @@ func TestDotReporterOnlyReportsAssertions(t *testing.T) {
 	monochrome()
 	file := newMemoryFile()
 	printer := NewPrinter(file)
-	reporter := NewDotReporter(printer)
+	reporter := NewDotReporter(printer, 0)
 
 	reporter.Enter(nil)
 	reporter.Exit()

--- a/convey/reporting/dot_test.go
+++ b/convey/reporting/dot_test.go
@@ -29,10 +29,9 @@ func TestDotReporterOnlyReportsAssertions(t *testing.T) {
 	printer := NewPrinter(file)
 	reporter := NewDotReporter(printer)
 
-	reporter.BeginStory(nil)
 	reporter.Enter(nil)
 	reporter.Exit()
-	reporter.EndStory()
+	reporter.Close()
 
 	if file.buffer != "" {
 		t.Errorf("\nExpected: '(blank)'\nActual:  '%s'", file.buffer)

--- a/convey/reporting/gotest.go
+++ b/convey/reporting/gotest.go
@@ -2,10 +2,6 @@ package reporting
 
 type gotestReporter struct{ test T }
 
-func (self *gotestReporter) BeginStory(story *StoryReport) {
-	self.test = story.Test
-}
-
 func (self *gotestReporter) Enter(scope *ScopeReport) {}
 
 func (self *gotestReporter) Report(r *AssertionResult) {
@@ -16,16 +12,14 @@ func (self *gotestReporter) Report(r *AssertionResult) {
 
 func (self *gotestReporter) Exit() {}
 
-func (self *gotestReporter) EndStory() {
-	self.test = nil
-}
+func (self *gotestReporter) Close() {}
 
 func (self *gotestReporter) Write(content []byte) (written int, err error) {
 	return len(content), nil // no-op
 }
 
-func NewGoTestReporter() *gotestReporter {
-	return new(gotestReporter)
+func NewGoTestReporter(t T) *gotestReporter {
+	return &gotestReporter{t}
 }
 
 func passed(r *AssertionResult) bool {

--- a/convey/reporting/gotest_test.go
+++ b/convey/reporting/gotest_test.go
@@ -3,9 +3,8 @@ package reporting
 import "testing"
 
 func TestReporterReceivesSuccessfulReport(t *testing.T) {
-	reporter := NewGoTestReporter()
 	test := new(fakeTest)
-	reporter.BeginStory(NewStoryReport(test))
+	reporter := NewGoTestReporter(test)
 	reporter.Report(NewSuccessReport())
 
 	if test.failed {
@@ -14,9 +13,8 @@ func TestReporterReceivesSuccessfulReport(t *testing.T) {
 }
 
 func TestReporterReceivesFailureReport(t *testing.T) {
-	reporter := NewGoTestReporter()
 	test := new(fakeTest)
-	reporter.BeginStory(NewStoryReport(test))
+	reporter := NewGoTestReporter(test)
 	reporter.Report(NewFailureReport("This is a failure."))
 
 	if !test.failed {
@@ -25,9 +23,8 @@ func TestReporterReceivesFailureReport(t *testing.T) {
 }
 
 func TestReporterReceivesErrorReport(t *testing.T) {
-	reporter := NewGoTestReporter()
 	test := new(fakeTest)
-	reporter.BeginStory(NewStoryReport(test))
+	reporter := NewGoTestReporter(test)
 	reporter.Report(NewErrorReport("This is an error."))
 
 	if !test.failed {
@@ -37,16 +34,16 @@ func TestReporterReceivesErrorReport(t *testing.T) {
 
 func TestReporterIsResetAtTheEndOfTheStory(t *testing.T) {
 	defer catch(t)
-	reporter := NewGoTestReporter()
 	test := new(fakeTest)
-	reporter.BeginStory(NewStoryReport(test))
-	reporter.EndStory()
+	reporter := NewGoTestReporter(test)
+	reporter.Close()
 
 	reporter.Report(NewSuccessReport())
 }
 
 func TestReporterNoopMethods(t *testing.T) {
-	reporter := NewGoTestReporter()
+	test := new(fakeTest)
+	reporter := NewGoTestReporter(test)
 	reporter.Enter(NewScopeReport("title"))
 	reporter.Exit()
 }

--- a/convey/reporting/init.go
+++ b/convey/reporting/init.go
@@ -17,32 +17,32 @@ func init() {
 	}
 }
 
-func BuildJsonReporter() Reporter {
+func BuildJsonReporter(t T, seed int64) Reporter {
 	out := NewPrinter(NewConsole())
 	return NewReporters(
-		NewGoTestReporter(),
-		NewJsonReporter(out))
+		NewGoTestReporter(t),
+		NewJsonReporter(out, seed))
 }
-func BuildDotReporter() Reporter {
+func BuildDotReporter(t T, seed int64) Reporter {
 	out := NewPrinter(NewConsole())
 	return NewReporters(
-		NewGoTestReporter(),
-		NewDotReporter(out),
+		NewGoTestReporter(t),
+		NewDotReporter(out, seed),
 		NewProblemReporter(out),
 		consoleStatistics)
 }
-func BuildStoryReporter() Reporter {
+func BuildStoryReporter(t T, seed int64) Reporter {
 	out := NewPrinter(NewConsole())
 	return NewReporters(
-		NewGoTestReporter(),
-		NewStoryReporter(out),
+		NewGoTestReporter(t),
+		NewStoryReporter(out, seed),
 		NewProblemReporter(out),
 		consoleStatistics)
 }
-func BuildSilentReporter() Reporter {
+func BuildSilentReporter(t T) Reporter {
 	out := NewPrinter(NewConsole())
 	return NewReporters(
-		NewGoTestReporter(),
+		NewGoTestReporter(t),
 		NewProblemReporter(out))
 }
 
@@ -62,9 +62,10 @@ var (
 
 var (
 	greenColor  = "\033[32m"
-	yellowColor = "\033[33m"
 	redColor    = "\033[31m"
 	resetColor  = "\033[0m"
+	whiteColor  = "\033[37;1m"
+	yellowColor = "\033[33m"
 )
 
 var consoleStatistics = NewStatisticsReporter(NewPrinter(NewConsole()))

--- a/convey/reporting/json.go
+++ b/convey/reporting/json.go
@@ -23,18 +23,6 @@ func (s *JsonReporter) Close() {
 		return stack[len(stack)-1]
 	}
 
-	if s.seed != 0 {
-		flattened = append(flattened, &ScopeResult{
-			Title:      "Random Seed",
-			Depth:      1,
-			Assertions: []*AssertionResult{},
-		}, &ScopeResult{
-			Title:      fmt.Sprint(s.seed),
-			Depth:      2,
-			Assertions: []*AssertionResult{},
-		})
-	}
-
 	s.Walk(func(obj interface{}) {
 		switch obj := obj.(type) {
 		case *NestedScopeResult:
@@ -58,6 +46,14 @@ func (s *JsonReporter) Close() {
 			top().Assertions = append(top().Assertions, obj)
 		}
 	})
+
+	if len(flattened) == 0 {
+		return
+	}
+
+	if s.seed != 0 {
+		flattened[0].RandomSeed = s.seed
+	}
 
 	scopes := []string{}
 	for _, scope := range flattened {

--- a/convey/reporting/json.go
+++ b/convey/reporting/json.go
@@ -10,70 +10,71 @@ import (
 )
 
 type JsonReporter struct {
-	out        *Printer
-	currentKey []string
-	current    *ScopeResult
-	index      map[string]*ScopeResult
-	scopes     []*ScopeResult
+	nestedReporter
+	out  *Printer
+	seed int64
 }
 
-func (self *JsonReporter) depth() int { return len(self.currentKey) }
+func (s *JsonReporter) Close() {
+	flattened := []*ScopeResult{}
+	stack := []*ScopeResult{}
 
-func (self *JsonReporter) BeginStory(story *StoryReport) {}
-
-func (self *JsonReporter) Enter(scope *ScopeReport) {
-	self.currentKey = append(self.currentKey, scope.Title)
-	ID := strings.Join(self.currentKey, "|")
-	if _, found := self.index[ID]; !found {
-		next := newScopeResult(scope.Title, self.depth(), scope.File, scope.Line)
-		self.scopes = append(self.scopes, next)
-		self.index[ID] = next
+	top := func() *ScopeResult {
+		return stack[len(stack)-1]
 	}
-	self.current = self.index[ID]
-}
 
-func (self *JsonReporter) Report(report *AssertionResult) {
-	self.current.Assertions = append(self.current.Assertions, report)
-}
+	if s.seed != 0 {
+		flattened = append(flattened, &ScopeResult{
+			Title:      "Random Seed",
+			Depth:      1,
+			Assertions: []*AssertionResult{},
+		}, &ScopeResult{
+			Title:      fmt.Sprint(s.seed),
+			Depth:      2,
+			Assertions: []*AssertionResult{},
+		})
+	}
 
-func (self *JsonReporter) Exit() {
-	self.currentKey = self.currentKey[:len(self.currentKey)-1]
-}
+	s.Walk(func(obj interface{}) {
+		switch obj := obj.(type) {
+		case *NestedScopeResult:
+			ent := &ScopeResult{
+				Title:      obj.Title,
+				File:       obj.File,
+				Line:       obj.Line,
+				Depth:      len(stack) + 1,
+				Assertions: []*AssertionResult{},
+			}
+			stack = append(stack, ent)
+			flattened = append(flattened, ent)
 
-func (self *JsonReporter) EndStory() {
-	self.report()
-	self.reset()
-}
-func (self *JsonReporter) report() {
+		case ScopeExit:
+			stack = stack[:len(stack)-1]
+
+		case string:
+			top().Output += obj
+
+		case *AssertionResult:
+			top().Assertions = append(top().Assertions, obj)
+		}
+	})
+
 	scopes := []string{}
-	for _, scope := range self.scopes {
+	for _, scope := range flattened {
 		serialized, err := json.Marshal(scope)
 		if err != nil {
-			self.out.Println(jsonMarshalFailure)
+			s.out.Statement(jsonMarshalFailure)
 			panic(err)
 		}
 		var buffer bytes.Buffer
 		json.Indent(&buffer, serialized, "", "  ")
 		scopes = append(scopes, buffer.String())
 	}
-	self.out.Print(fmt.Sprintf("%s\n%s,\n%s\n", OpenJson, strings.Join(scopes, ","), CloseJson))
-}
-func (self *JsonReporter) reset() {
-	self.scopes = []*ScopeResult{}
-	self.index = map[string]*ScopeResult{}
-	self.currentKey = nil
+	s.out.Insert(fmt.Sprintf("%s\n%s,\n%s\n", OpenJson, strings.Join(scopes, ","), CloseJson))
 }
 
-func (self *JsonReporter) Write(content []byte) (written int, err error) {
-	self.current.Output += string(content)
-	return len(content), nil
-}
-
-func NewJsonReporter(out *Printer) *JsonReporter {
-	self := new(JsonReporter)
-	self.out = out
-	self.reset()
-	return self
+func NewJsonReporter(out *Printer, seed int64) Reporter {
+	return &JsonReporter{out: out, seed: seed}
 }
 
 const OpenJson = ">->->OPEN-JSON->->->"   // "⌦"

--- a/convey/reporting/nested.go
+++ b/convey/reporting/nested.go
@@ -1,0 +1,68 @@
+package reporting
+
+// nestedReporter buffers scopes from Enter, Exit, Report, and Write so you only
+// need to implement the pertinent details of Close().
+//
+// In particular, it's smart about the stack of scopes so that it will render:
+//
+//   A
+//     B
+//       C
+//   A
+//     B
+//       D
+//
+// As:
+//
+//   A
+//     B
+//       C
+//       D
+type nestedReporter struct {
+	root *NestedScopeResult
+	cur  *NestedScopeResult
+}
+
+func (self *nestedReporter) Walk(cb func(interface{})) {
+	self.root.Walk(cb)
+}
+
+func (self *nestedReporter) Enter(scope *ScopeReport) {
+	if self.root == nil {
+		self.root = &NestedScopeResult{}
+		self.cur = self.root
+	}
+
+	// If the last thing at the current level of the tree is a scope whose Title
+	// matches ours, then use that!
+	if len(self.cur.Items) > 0 {
+		lastItm := self.cur.Items[len(self.cur.Items)-1]
+		if s, ok := lastItm.(*NestedScopeResult); ok {
+			if s.Title == scope.Title {
+				self.cur = s
+				return
+			}
+		}
+	}
+
+	// Otherwise make a new one
+	newScope := NewNestedScopeResult(self.cur, scope)
+	self.cur.Items = append(self.cur.Items, newScope)
+	self.cur = newScope
+}
+
+func (self *nestedReporter) Report(report *AssertionResult) {
+	self.cur.Items = append(self.cur.Items, report)
+}
+
+func (self *nestedReporter) Exit() {
+	self.cur = self.cur.Parent
+	if self.cur == nil { // in case the caller overshoots
+		self.cur = self.root
+	}
+}
+
+func (self *nestedReporter) Write(content []byte) (written int, err error) {
+	self.cur.Items = append(self.cur.Items, string(content))
+	return len(content), nil
+}

--- a/convey/reporting/problems_test.go
+++ b/convey/reporting/problems_test.go
@@ -7,7 +7,6 @@ import (
 
 func TestNoopProblemReporterActions(t *testing.T) {
 	file, reporter := setup()
-	reporter.BeginStory(nil)
 	reporter.Enter(nil)
 	reporter.Exit()
 	expected := ""
@@ -22,7 +21,7 @@ func TestReporterPrintsFailuresAndErrorsAtTheEndOfTheStory(t *testing.T) {
 	reporter.Report(NewFailureReport("failed"))
 	reporter.Report(NewErrorReport("error"))
 	reporter.Report(NewSuccessReport())
-	reporter.EndStory()
+	reporter.Close()
 
 	result := file.String()
 	if !strings.Contains(result, "Errors:\n") {

--- a/convey/reporting/reporter.go
+++ b/convey/reporting/reporter.go
@@ -3,21 +3,19 @@ package reporting
 import "io"
 
 type Reporter interface {
-	BeginStory(story *StoryReport)
 	Enter(scope *ScopeReport)
 	Report(r *AssertionResult)
 	Exit()
-	EndStory()
+	Close()
 	io.Writer
 }
 
 type reporters struct{ collection []Reporter }
 
-func (self *reporters) BeginStory(s *StoryReport) { self.foreach(func(r Reporter) { r.BeginStory(s) }) }
 func (self *reporters) Enter(s *ScopeReport)      { self.foreach(func(r Reporter) { r.Enter(s) }) }
 func (self *reporters) Report(a *AssertionResult) { self.foreach(func(r Reporter) { r.Report(a) }) }
 func (self *reporters) Exit()                     { self.foreach(func(r Reporter) { r.Exit() }) }
-func (self *reporters) EndStory()                 { self.foreach(func(r Reporter) { r.EndStory() }) }
+func (self *reporters) Close()                    { self.foreach(func(r Reporter) { r.Close() }) }
 
 func (self *reporters) Write(contents []byte) (written int, err error) {
 	self.foreach(func(r Reporter) {

--- a/convey/reporting/reporter_test.go
+++ b/convey/reporting/reporter_test.go
@@ -10,7 +10,6 @@ func TestEachNestedReporterReceivesTheCallFromTheContainingReporter(t *testing.T
 	fake2 := newFakeReporter()
 	reporter := NewReporters(fake1, fake2)
 
-	reporter.BeginStory(nil)
 	assertTrue(t, fake1.begun)
 	assertTrue(t, fake2.begun)
 
@@ -26,7 +25,7 @@ func TestEachNestedReporterReceivesTheCallFromTheContainingReporter(t *testing.T
 	assertTrue(t, fake1.exited)
 	assertTrue(t, fake2.exited)
 
-	reporter.EndStory()
+	reporter.Close()
 	assertTrue(t, fake1.ended)
 	assertTrue(t, fake2.ended)
 
@@ -56,7 +55,7 @@ func assertEqual(t *testing.T, expected, actual int) {
 func assertNil(t *testing.T, err error) {
 	if err != nil {
 		_, _, line, _ := runtime.Caller(1)
-		t.Errorf("Error should have been <nil> (but wasn't). See line %d", err, line)
+		t.Errorf("Error should have been <nil> (but wasn't). See line %d", line)
 	}
 }
 
@@ -70,12 +69,9 @@ type fakeReporter struct {
 }
 
 func newFakeReporter() *fakeReporter {
-	return &fakeReporter{}
+	return &fakeReporter{begun: true}
 }
 
-func (self *fakeReporter) BeginStory(story *StoryReport) {
-	self.begun = true
-}
 func (self *fakeReporter) Enter(scope *ScopeReport) {
 	self.entered = true
 }
@@ -85,7 +81,7 @@ func (self *fakeReporter) Report(report *AssertionResult) {
 func (self *fakeReporter) Exit() {
 	self.exited = true
 }
-func (self *fakeReporter) EndStory() {
+func (self *fakeReporter) Close() {
 	self.ended = true
 }
 func (self *fakeReporter) Write(content []byte) (int, error) {

--- a/convey/reporting/reports.go
+++ b/convey/reporting/reports.go
@@ -32,6 +32,7 @@ type ScopeResult struct {
 	Depth      int
 	Assertions []*AssertionResult
 	Output     string
+	RandomSeed int64 `json:",omitempty"`
 }
 
 ////////////////// NestedScopeResult ////////////////////

--- a/convey/reporting/statistics.go
+++ b/convey/reporting/statistics.go
@@ -2,7 +2,7 @@ package reporting
 
 import "fmt"
 
-func (self *statistics) BeginStory(story *StoryReport) {}
+func (self *statistics) BeginStory() {}
 
 func (self *statistics) Enter(scope *ScopeReport) {}
 
@@ -22,14 +22,15 @@ func (self *statistics) Report(report *AssertionResult) {
 
 func (self *statistics) Exit() {}
 
-func (self *statistics) EndStory() {
+func (self *statistics) Close() {
 	self.reportAssertions()
 	self.reportSkippedSections()
 	self.completeReport()
 }
 func (self *statistics) reportAssertions() {
 	self.decideColor()
-	self.out.Print("\n%d %s thus far", self.total, plural("assertion", self.total))
+	self.out.Statement(
+		fmt.Sprintf("\n%d %s thus far", self.total, plural("assertion", self.total)))
 }
 func (self *statistics) decideColor() {
 	if self.failing && !self.erroring {
@@ -43,14 +44,13 @@ func (self *statistics) decideColor() {
 func (self *statistics) reportSkippedSections() {
 	if self.skipped > 0 {
 		fmt.Print(yellowColor)
-		self.out.Print(" (one or more sections skipped)")
+		self.out.Expression(" (one or more sections skipped)")
 		self.skipped = 0
 	}
 }
 func (self *statistics) completeReport() {
-	fmt.Print(resetColor)
-	self.out.Print("\n")
-	self.out.Print("\n")
+	self.out.Insert(resetColor)
+	self.out.Insert("\n\n")
 }
 
 func (self *statistics) Write(content []byte) (written int, err error) {

--- a/convey/reporting_hooks_test.go
+++ b/convey/reporting_hooks_test.go
@@ -256,6 +256,16 @@ func expectEqual(t *testing.T, expected interface{}, actual interface{}) {
 	}
 }
 
+func expectEqualCtx(t *testing.T, expected interface{}, actual interface{}, format string, args ...interface{}) {
+	if expected != actual {
+		_, file, line, _ := runtime.Caller(1)
+		err := fmt.Sprintf("Expected '%v' to be '%v' but it wasn't. See '%s' at line %d.",
+			actual, expected, path.Base(file), line)
+		err += fmt.Sprintf("\n  Context: "+format, args...)
+		t.Errorf(err)
+	}
+}
+
 func setupFakeReporter() (*fakeReporter, *fakeGoTest) {
 	myReporter := new(fakeReporter)
 	myReporter.calls = []string{}

--- a/convey/reporting_hooks_test.go
+++ b/convey/reporting_hooks_test.go
@@ -267,18 +267,13 @@ func expectEqualCtx(t *testing.T, expected interface{}, actual interface{}, form
 }
 
 func setupFakeReporter() (*fakeReporter, *fakeGoTest) {
-	myReporter := new(fakeReporter)
-	myReporter.calls = []string{}
+	myReporter := &fakeReporter{[]string{"Begin"}}
 	testReporter = myReporter
 	return myReporter, new(fakeGoTest)
 }
 
 type fakeReporter struct {
 	calls []string
-}
-
-func (self *fakeReporter) BeginStory(story *reporting.StoryReport) {
-	self.calls = append(self.calls, "Begin")
 }
 
 func (self *fakeReporter) Enter(scope *reporting.ScopeReport) {
@@ -305,7 +300,7 @@ func (self *fakeReporter) Exit() {
 	self.calls = append(self.calls, "Exit")
 }
 
-func (self *fakeReporter) EndStory() {
+func (self *fakeReporter) Close() {
 	self.calls = append(self.calls, "End")
 }
 


### PR DESCRIPTION
So... that wasn't too bad either :) However, the test output (both story and json) are basically garbled junk :(.

What's the right thing to do with reporting? I could:
  1. buffer everything till the end and emit it in a stable sort order
  1. stream the output (but emit stories multiple times)
  1. ???

1 is pretty explanatory

2 would be something like:
```go
Convey("A", t, func() {
  Convey("B", func() {
    Convey("C", nil)
    Convey("D", nil)
  })  
  Convey("F", func() {
    Convey("G", nil)
  })
})
```

Could emit:
```
A
  B
    C
  F
    G
  B
    D
```
(assuming that's how they randomized).

Or is there another idea?