### PR TITLE
convert ansi colour sequences to coloured span tags

### DIFF
--- a/web/client/index.html
+++ b/web/client/index.html
@@ -9,6 +9,7 @@
 		<link rel="shortcut icon" class="favicon" href="/favicon.ico" type="image/vnd.microsoft.icon">
 		<script src="/resources/js/lib/markup.min.js"></script>
 		<script src="/resources/js/lib/moment.min.js"></script>
+		<script src="/resources/js/lib/ansispan.js"></script>
 		<script src="/resources/js/lib/diff-match-patch.min.js"></script>
 		<script src="/resources/js/lib/jquery-2_1_0.min.js"></script>
 		<script src="/resources/js/lib/jquery-ui-1_10_3-custom.min.js"></script>
@@ -233,7 +234,7 @@
 						{{.}}
 						<div class="buildfail">
 							<div class="buildfail-pkg"><i class="fa fa-wrench"></i>&nbsp; {{PackageName|boldPkgName}}</div>
-							<div class="buildfail-output">{{BuildOutput|htmlSafe}}</div>
+							<div class="buildfail-output">{{BuildOutput|htmlSafe|ansiColours}}</div>
 						</div>
 						{{/.}}
 					</div>
@@ -268,7 +269,7 @@
 					{{/if}}
 							{{if StackTrace|notempty}}<div class="depth-{{_maxDepth}} panic-summary">{{Error}}</div>{{/if}}
 							</div>
-							<div class="panic-output">{{if StackTrace|empty}}{{Error|htmlSafe}}{{else}}{{StackTrace|htmlSafe}}{{/if}}</div>
+							<div class="panic-output">{{if StackTrace|empty}}{{Error|htmlSafe|ansiColours}}{{else}}{{StackTrace|htmlSafe|ansiColours}}{{/if}}</div>
 						</div>
 						{{/.}}
 					</div>
@@ -301,16 +302,16 @@
 								{{/_path}}
 							{{/if}}
 								</div>
-								<div class="failure-output">{{if Failure|notempty}}{{Failure|htmlSafe}}{{else}}{{if Message|notempty}}{{Message|htmlSafe}}{{else}}{{StackTrace|htmlSafe}}{{/if}}{{/if}}</div>
+								<div class="failure-output">{{if Failure|notempty}}{{Failure|htmlSafe|ansiColours}}{{else}}{{if Message|notempty}}{{Message|htmlSafe|ansiColours}}{{else}}{{StackTrace|htmlSafe|ansiColours}}{{/if}}{{/if}}</div>
 								{{if .|needsDiff}}
 								<table class="diffviewer">
 									<tr>
 										<td class="exp">Expected</td>
-										<td class="original">{{Expected|htmlSafe}}</td>
+										<td class="original">{{Expected|htmlSafe|ansiColours}}</td>
 									</tr>
 									<tr>
 										<td class="act">Actual</td>
-										<td class="changed">{{Actual|htmlSafe}}</td>
+										<td class="changed">{{Actual|htmlSafe|ansiColours}}</td>
 									</tr>
 									<tr>
 										<td>Diff</td>
@@ -375,8 +376,8 @@
 
 							</td>
 							<td colspan="3" class="depth-0 story-line-desc">
-								<b>{{TestName|htmlSafe}}</b>
-								{{if Message}}<div class="message">{{Message|htmlSafe}}</div>{{/if}}
+								<b>{{TestName|htmlSafe|ansiColours}}</b>
+								{{if Message}}<div class="message">{{Message|htmlSafe|ansiColours}}</div>{{/if}}
 							</td>
 						</tr>
 
@@ -394,15 +395,15 @@
 
 								</td>
 								<td colspan="3" class="depth-{{Depth}} story-line-desc">
-									{{Title|htmlSafe}}
-									{{if Output}}<div class="message">{{Output|htmlSafe}}</div>{{/if}}
+									{{Title|htmlSafe|ansiColours}}
+									{{if Output}}<div class="message">{{Output|htmlSafe|ansiColours}}</div>{{/if}}
 									{{if _failed}}
 										{{Assertions}}
 											{{if _failed}}
 											<div class="failure">
 												<div class="failure-details">
-													<div class="failure-output">{{if Failure|notempty}}{{Failure|htmlSafe}}{{else}}{{if Message|notempty}}{{Message|htmlSafe}}{{else}}
-															{{StackTrace|htmlSafe}}{{/if}}{{/if}}</div>
+													<div class="failure-output">{{if Failure|notempty}}{{Failure|htmlSafe|ansiColours}}{{else}}{{if Message|notempty}}{{Message|htmlSafe|ansiColours}}{{else}}
+															{{StackTrace|htmlSafe|ansiColours}}{{/if}}{{/if}}</div>
 												</div>
 											</div>
 											{{/if}}
@@ -413,7 +414,7 @@
 											{{if _panicked}}
 											<div class="panic">
 												<div class="panic-details">
-													<div class="panic-output">{{if Panic|notempty}}{{Panic|htmlSafe}}{{else}}{{if Message|notempty}}{{Message|htmlSafe}}{{else}}{{StackTrace|htmlSafe}}{{/if}}{{/if}}</div>
+													<div class="panic-output">{{if Panic|notempty}}{{Panic|htmlSafe|ansiColours}}{{else}}{{if Message|notempty}}{{Message|htmlSafe|ansiColours}}{{else}}{{StackTrace|htmlSafe|ansiColours}}{{/if}}{{/if}}</div>
 												</div>
 											</div>
 											{{/if}}

--- a/web/client/resources/css/themes/dark.css
+++ b/web/client/resources/css/themes/dark.css
@@ -349,6 +349,8 @@ footer .recording.replay .fa {
 .statusicon.panic, .statusicon.panic .fa, .panic-clr { color: #FF3232; }
 .statusicon.skip, .skip-clr { color: #888; }
 
+.ansi-green { color: #76C13C; }
+.ansi-yellow   { color: #EA9C4D; }
 
 .log .timestamp {
 	color: #999;

--- a/web/client/resources/css/themes/light.css
+++ b/web/client/resources/css/themes/light.css
@@ -297,7 +297,8 @@ footer .paused .fa {
 .statusicon.panic, .statusicon.panic .fa, .panic-clr { color: #FF3232; }
 .statusicon.skip, .skip-clr { color: #AAA; }
 
-
+.ansi-green { color: #76C13C; }
+.ansi-yellow   { color: #EA9C4D; }
 
 .log .timestamp {
 	color: #999;

--- a/web/client/resources/js/goconvey.js
+++ b/web/client/resources/js/goconvey.js
@@ -1274,6 +1274,7 @@ function customMarkupPipes()
 	{
 		return str.replace(/</g, "&lt;").replace(/>/g, "&gt;");
 	};
+	Mark.pipes.ansiColours = ansispan;
 	Mark.pipes.boldPkgName = function(str)
 	{
 		var pkg = splitPathName(str);

--- a/web/client/resources/js/lib/ansispan.js
+++ b/web/client/resources/js/lib/ansispan.js
@@ -1,0 +1,67 @@
+/*
+Copyright (C) 2011 by Maciej Małecki
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+var ansispan = function (str) {
+  Object.keys(ansispan.foregroundColors).forEach(function (ansi) {
+    var span = '<span class="ansi-' + ansispan.foregroundColors[ansi] + '">';
+
+    //
+    // `\033[Xm` == `\033[0;Xm` sets foreground color to `X`.
+    //
+
+    str = str.replace(
+      new RegExp('\033\\[' + ansi + 'm', 'g'),
+      span
+    ).replace(
+      new RegExp('\033\\[0;' + ansi + 'm', 'g'),
+      span
+    );
+  });
+  //
+  // `\033[1m` enables bold font, `\033[22m` disables it
+  //
+  str = str.replace(/\033\[1m/g, '<b>').replace(/\033\[22m/g, '</b>');
+
+  //
+  // `\033[3m` enables italics font, `\033[23m` disables it
+  //
+  str = str.replace(/\033\[3m/g, '<i>').replace(/\033\[23m/g, '</i>');
+
+  str = str.replace(/\033\[m/g, '</span>');
+  str = str.replace(/\033\[0m/g, '</span>');
+  return str.replace(/\033\[39m/g, '</span>');
+};
+
+ansispan.foregroundColors = {
+  '30': 'black',
+  '31': 'red',
+  '32': 'green',
+  '33': 'yellow',
+  '34': 'blue',
+  '35': 'purple',
+  '36': 'cyan',
+  '37': 'white'
+};
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = ansispan;
+}


### PR DESCRIPTION
Some testing packages (such as goconvey itself) will colour the output with ANSI escape sequences; the web view will display them as, for example, "[32m✔[0m", which gets noisy very quickly. This patch converts them to span tags with colour classes.

This is based on https://github.com/mmalecki/ansispan