### PR TITLE
fix for issue 270: a path containing .go is no longer evaluated as hidde...

### DIFF
--- a/web/server/watch/functional_core.go
+++ b/web/server/watch/functional_core.go
@@ -40,7 +40,8 @@ func foundInHiddenDirectory(item *FileSystemItem, root string) bool {
 	return false
 }
 func isHidden(path string) bool {
-	return strings.HasPrefix(path, ".") || strings.HasPrefix(path, "_")
+	return !strings.HasPrefix(path, ".go") && 
+		(strings.HasPrefix(path, ".") || strings.HasPrefix(path, "_"))
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/web/server/watch/functional_core_test.go
+++ b/web/server/watch/functional_core_test.go
@@ -94,6 +94,15 @@ func TestCategorize(t *testing.T) {
 		So(profiles, ShouldResemble, fileSystem[8:9])
 		So(goFiles, ShouldResemble, fileSystem[2:4])
 	})
+
+	Convey("A '.go' as path section should not result in a hidden path", t, func() {
+
+		item := FileSystemItem{Path: "/.go/test"}
+		isHidden := foundInHiddenDirectory(&item, "/.go/test")
+
+		So(isHidden, ShouldBeFalse)
+	})	
+	
 }
 
 func TestParseProfile(t *testing.T) {


### PR DESCRIPTION
Tracking the problem described in  #270 I found this was caused by the go path (e.g. ~/.go/src/smartystreets/goconey) being interpreted as a hidden directory and therefore not marked as *active*. 

Only changes from active files or directories get tracked. This resulted in all changes being ignored.

This fix changes *isHidden()* to make it accept '.go' as a valid, not hidden section, of a path.

This works on my mac, but I'm not sure if this is the correct way or will work on other platforms. ;-)