### PR TITLE
Dereference root path if it is a symlink so Walk works

### DIFF
--- a/web/server/watch/imperative_shell.go
+++ b/web/server/watch/imperative_shell.go
@@ -25,6 +25,14 @@ type FileSystemItem struct {
 func YieldFileSystemItems(root string) chan *FileSystemItem {
 	items := make(chan *FileSystemItem)
 
+	if info, err := os.Lstat(root); err == nil {
+		if info.Mode()&os.ModeSymlink != 0 {
+			if path, err := filepath.EvalSymlinks(root); err == nil {
+				root = path
+			}
+		}
+	}
+
 	go func() {
 		filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
 			if err != nil {


### PR DESCRIPTION
This is patch 2/2 (patch 1 is #290) to fix the issue I reported in #270.