### PR TITLE
fixes issue: Cmd+C or Ctrl+C shouldn't open composer #252

### DIFF
--- a/web/client/resources/js/goconvey.js
+++ b/web/client/resources/js/goconvey.js
@@ -362,7 +362,7 @@ function wireup()
 	});
 
 	// Keyboard shortcuts!
-	$(document).keyup(function(e)
+	$(document).keydown(function(e)
 	{
 		if (e.ctrlKey || e.metaKey || e.shiftKey)
 			return;


### PR DESCRIPTION
Using keydown instead of keyup insures that if ctrl/command is pushed down the shortcut won't proceed. 