### PR TITLE
Pass the commandline host parameter to ListenAndServe

### DIFF
--- a/goconvey.go
+++ b/goconvey.go
@@ -135,7 +135,7 @@ func serveAjaxMethods(server contract.Server) {
 
 func activateServer() {
 	log.Printf("Serving HTTP at: http://%s:%d\n", host, port)
-	err := http.ListenAndServe(fmt.Sprintf(":%d", port), nil)
+	err := http.ListenAndServe(fmt.Sprintf("%s:%d", host, port), nil)
 	if err != nil {
 		log.Println(err)
 	}


### PR DESCRIPTION
This makes goconvey's http server bind only to 127.0.0.1 by default, keeping
it from being exposed to the rest of the network.

Fixes #300