### PR TITLE
change to GOPATH parsing for GOPATHs containing "src"

### DIFF
--- a/web/server/contract/result.go
+++ b/web/server/contract/result.go
@@ -101,13 +101,8 @@ func NewTestResult(testName string) *TestResult {
 }
 
 func resolvePackageName(path string) string {
-	index := strings.Index(path, endGoPath)
-	if index < 0 {
-		return path
-	}
-	packageBeginning := index + len(endGoPath)
-	name := path[packageBeginning:]
-	return name
+	nameArr := strings.Split(path, endGoPath)
+	return nameArr[len(nameArr)-1]
 }
 
 const (


### PR DESCRIPTION
My $GOPATH looks like: `~/src/go`

Which resulted in load errors like so:
```
2015/01/26 15:45:06 shell.go:93: Please run goconvey from within your $GOPATH (symlinks might be problematic). Output and Error:  can't load package: package go/src/github.com/me/mypackage: cannot find package "go/src/github.com/me/mypackage" in any of:
	/usr/local/go/src/go/src/github.com/me/mypackage (from $GOROOT)
	/Users/me/src/go/src/go/src/github.com/me/mypackage (from $GOPATH)
 exit status 1
```

This makes the minor change of splitting on the same `endGoPath` token, then returning the last item.