### PR TITLE
Fix #310: Re-execute only when it makes sense

### DIFF
--- a/web/server/watch/integration.go
+++ b/web/server/watch/integration.go
@@ -72,12 +72,16 @@ func (this *Watcher) respond(command messaging.WatcherCommand) {
 	case messaging.WatcherIgnore:
 		log.Println("Ignoring specified folders")
 		this.ignore(command.Details)
-		this.execute()
+		// Prevent a filesystem change due to the number of active folders changing
+		_, checksum := this.gather()
+		this.set(checksum)
 
 	case messaging.WatcherReinstate:
 		log.Println("Reinstating specified folders")
 		this.reinstate(command.Details)
-		this.execute()
+		// Prevent a filesystem change due to the number of active folders changing
+		_, checksum := this.gather()
+		this.set(checksum)
 
 	case messaging.WatcherPause:
 		log.Println("Pausing watcher...")
@@ -86,7 +90,6 @@ func (this *Watcher) respond(command messaging.WatcherCommand) {
 	case messaging.WatcherResume:
 		log.Println("Resuming watcher...")
 		this.paused = false
-		this.execute()
 
 	case messaging.WatcherExecute:
 		log.Println("Gathering folders for immediate execution...")

--- a/web/server/watch/integration_test.go
+++ b/web/server/watch/integration_test.go
@@ -93,7 +93,7 @@ func TestWatcher(t *testing.T) {
 			So(len(results[1]), ShouldEqual, 2)
 		})
 
-		Convey("Ignore and Reinstate commands are reflected in the scan results", func() {
+		Convey("Ignore and Reinstate commands are not reflected in the scan results", func() {
 			go func() {
 				input <- ignore
 				input <- reinstate
@@ -105,10 +105,8 @@ func TestWatcher(t *testing.T) {
 				results = append(results, result)
 			}
 
-			So(len(results), ShouldEqual, 3)
+			So(len(results), ShouldEqual, 1)
 			So(results[0][sub].Ignored, ShouldBeFalse) // initial
-			So(results[1][sub].Ignored, ShouldBeTrue)  // ignored
-			So(results[2][sub].Ignored, ShouldBeFalse) // reinstated
 		})
 
 		Convey("Adjusting the root changes the number of folders in the scanned results", func() {
@@ -159,7 +157,7 @@ func TestWatcher(t *testing.T) {
 			So(len(results), ShouldEqual, 2)
 		})
 
-		Convey("Scanning occurs as a result of resuming after a pause", func() {
+		Convey("Scanning does not occur as a result of resuming after a pause", func() {
 			go func() {
 				input <- pause
 				input <- resume
@@ -171,7 +169,7 @@ func TestWatcher(t *testing.T) {
 				results = append(results, result)
 			}
 
-			So(len(results), ShouldEqual, 2)
+			So(len(results), ShouldEqual, 1)
 		})
 
 		Convey("Scanning should not occur when the watcher is paused", func() {


### PR DESCRIPTION
Change watcher behavior to avoid unnecessary re-execution of tests.

- When a package is ignored, never re-execute
- When a package is reinstated, run tests unless the watcher is paused