### PR TITLE
Parse tags option

### DIFF
--- a/web/server/contract/contracts.go
+++ b/web/server/contract/contracts.go
@@ -22,6 +22,6 @@ type (
 	}
 
 	Shell interface {
-		GoTest(directory, packageName string, arguments []string) (output string, err error)
+		GoTest(directory, packageName string, tags, arguments []string) (output string, err error)
 	}
 )

--- a/web/server/contract/result.go
+++ b/web/server/contract/result.go
@@ -15,6 +15,7 @@ type Package struct {
 	Name          string
 	Ignored       bool
 	Disabled      bool
+	BuildTags     []string
 	TestArguments []string
 	Error         error
 	Output        string
@@ -30,6 +31,7 @@ func NewPackage(folder *messaging.Folder, hasImportCycle bool) *Package {
 	self.Result = NewPackageResult(self.Name)
 	self.Ignored = folder.Ignored
 	self.Disabled = folder.Disabled
+	self.BuildTags = folder.BuildTags
 	self.TestArguments = folder.TestArguments
 	self.HasImportCycle = hasImportCycle
 	return self

--- a/web/server/executor/coordinator.go
+++ b/web/server/executor/coordinator.go
@@ -44,7 +44,7 @@ func (self *concurrentCoordinator) worker(id int) {
 			folder.Output, folder.Error = message, errors.New(message)
 		} else {
 			log.Printf("Executing concurrent tests: %s\n", packageName)
-			folder.Output, folder.Error = self.shell.GoTest(folder.Path, packageName, folder.TestArguments)
+			folder.Output, folder.Error = self.shell.GoTest(folder.Path, packageName, folder.BuildTags, folder.TestArguments)
 		}
 	}
 	self.waiter.Done()

--- a/web/server/executor/tester.go
+++ b/web/server/executor/tester.go
@@ -41,7 +41,7 @@ func (self *ConcurrentTester) executeSynchronously(folders []*contract.Package) 
 			folder.Output, folder.Error = message, errors.New(message)
 		} else {
 			log.Printf("Executing tests: %s\n", packageName)
-			folder.Output, folder.Error = self.shell.GoTest(folder.Path, packageName, folder.TestArguments)
+			folder.Output, folder.Error = self.shell.GoTest(folder.Path, packageName, folder.BuildTags, folder.TestArguments)
 		}
 	}
 }

--- a/web/server/executor/tester_test.go
+++ b/web/server/executor/tester_test.go
@@ -83,13 +83,13 @@ func NewTesterFixture() *TesterFixture {
 	self.shell = NewTimedShell()
 	self.tester = NewConcurrentTester(self.shell)
 	self.packages = []*contract.Package{
-		&contract.Package{Path: "a"},
-		&contract.Package{Path: "b"},
-		&contract.Package{Path: "c"},
-		&contract.Package{Path: "d"},
-		&contract.Package{Path: "e", Ignored: true},
-		&contract.Package{Path: "f"},
-		&contract.Package{Path: "g", HasImportCycle: true},
+		{Path: "a"},
+		{Path: "b"},
+		{Path: "c"},
+		{Path: "d"},
+		{Path: "e", Ignored: true},
+		{Path: "f"},
+		{Path: "g", HasImportCycle: true},
 	}
 	return self
 }
@@ -225,7 +225,7 @@ func (self *TimedShell) setExitWithError() {
 	self.err = errors.New("Simulate test failure")
 }
 
-func (self *TimedShell) GoTest(directory, packageName string, arguments []string) (output string, err error) {
+func (self *TimedShell) GoTest(directory, packageName string, arguments, tags []string) (output string, err error) {
 	if self.panicMessage != "" {
 		return "", errors.New(self.panicMessage)
 	}

--- a/web/server/messaging/messages.go
+++ b/web/server/messaging/messages.go
@@ -49,6 +49,7 @@ type Folder struct {
 	Root          string
 	Ignored       bool
 	Disabled      bool
+	BuildTags     []string
 	TestArguments []string
 }
 

--- a/web/server/system/shell.go
+++ b/web/server/system/shell.go
@@ -28,16 +28,17 @@ func NewShell(gobin, reportsPath string, coverage bool, defaultTimeout string) *
 	}
 }
 
-func (self *Shell) GoTest(directory, packageName string, arguments []string) (output string, err error) {
+func (self *Shell) GoTest(directory, packageName string, tags, arguments []string) (output string, err error) {
 	reportFilename := strings.Replace(packageName, "/", "-", -1)
 	reportPath := filepath.Join(self.reportsPath, reportFilename)
 	reportData := reportPath + ".txt"
 	reportHTML := reportPath + ".html"
+	tagsArg := "-tags=" + strings.Join(tags, ",")
 
-	goconvey := findGoConvey(directory, self.gobin, packageName).Execute()
-	compilation := compile(directory, self.gobin).Execute()
-	withCoverage := runWithCoverage(compilation, goconvey, self.coverage, reportData, directory, self.gobin, self.defaultTimeout, arguments).Execute()
-	final := runWithoutCoverage(compilation, withCoverage, goconvey, directory, self.gobin, self.defaultTimeout, arguments).Execute()
+	goconvey := findGoConvey(directory, self.gobin, packageName, tagsArg).Execute()
+	compilation := compile(directory, self.gobin, tagsArg).Execute()
+	withCoverage := runWithCoverage(compilation, goconvey, self.coverage, reportData, directory, self.gobin, self.defaultTimeout, tagsArg, arguments).Execute()
+	final := runWithoutCoverage(compilation, withCoverage, goconvey, directory, self.gobin, self.defaultTimeout, tagsArg, arguments).Execute()
 	go generateReports(final, self.coverage, directory, self.gobin, reportData, reportHTML).Execute()
 
 	return final.Output, final.Error
@@ -47,15 +48,15 @@ func (self *Shell) GoTest(directory, packageName string, arguments []string) (ou
 // Functional Core:////////////////////////////////////////////////////////////
 ///////////////////////////////////////////////////////////////////////////////
 
-func findGoConvey(directory, gobin, packageName string) Command {
-	return NewCommand(directory, gobin, "list", "-f", "'{{.TestImports}}'", packageName)
+func findGoConvey(directory, gobin, packageName, tagsArg string) Command {
+	return NewCommand(directory, gobin, "list", "-f", "'{{.TestImports}}'", tagsArg, packageName)
 }
 
-func compile(directory, gobin string) Command {
-	return NewCommand(directory, gobin, "test", "-i")
+func compile(directory, gobin, tagsArg string) Command {
+	return NewCommand(directory, gobin, "test", "-i", tagsArg)
 }
 
-func runWithCoverage(compile, goconvey Command, coverage bool, reportPath, directory, gobin, defaultTimeout string, customArguments []string) Command {
+func runWithCoverage(compile, goconvey Command, coverage bool, reportPath, directory, gobin, defaultTimeout, tagsArg string, customArguments []string) Command {
 	if compile.Error != nil || goconvey.Error != nil {
 		return compile
 	}
@@ -64,7 +65,7 @@ func runWithCoverage(compile, goconvey Command, coverage bool, reportPath, direc
 		return compile
 	}
 
-	arguments := []string{"test", "-v", "-coverprofile=" + reportPath}
+	arguments := []string{"test", "-v", "-coverprofile=" + reportPath, tagsArg}
 
 	customArgsText := strings.Join(customArguments, "\t")
 	if !strings.Contains(customArgsText, "-covermode=") {
@@ -84,7 +85,7 @@ func runWithCoverage(compile, goconvey Command, coverage bool, reportPath, direc
 	return NewCommand(directory, gobin, arguments...)
 }
 
-func runWithoutCoverage(compile, withCoverage, goconvey Command, directory, gobin, defaultTimeout string, customArguments []string) Command {
+func runWithoutCoverage(compile, withCoverage, goconvey Command, directory, gobin, defaultTimeout, tagsArg string, customArguments []string) Command {
 	if compile.Error != nil {
 		return compile
 	}
@@ -102,7 +103,7 @@ func runWithoutCoverage(compile, withCoverage, goconvey Command, directory, gobi
 
 	log.Print("Run without coverage")
 
-	arguments := []string{"test", "-v"}
+	arguments := []string{"test", "-v", tagsArg}
 	customArgsText := strings.Join(customArguments, "\t")
 	if !strings.Contains(customArgsText, "-timeout=") {
 		arguments = append(arguments, "-timeout="+defaultTimeout)

--- a/web/server/system/shell_integration_test.go
+++ b/web/server/system/shell_integration_test.go
@@ -22,7 +22,7 @@ func TestShellIntegration(t *testing.T) {
 	packageName := "github.com/smartystreets/goconvey/web/server/watch/integration_testing/sub"
 
 	shell := NewShell("go", "", true, "5s")
-	output, err := shell.GoTest(directory, packageName, []string{"-short"})
+	output, err := shell.GoTest(directory, packageName, []string{}, []string{"-short"})
 
 	if !strings.Contains(output, "PASS\n") || !strings.Contains(output, "ok") {
 		t.Errorf("Expected output that resembed tests passing but got this instead: [%s]", output)

--- a/web/server/system/shell_test.go
+++ b/web/server/system/shell_test.go
@@ -33,7 +33,7 @@ func TestShellCommandComposition(t *testing.T) {
 
 	Convey("When attempting to run tests with coverage flags", t, func() {
 		Convey("And buildSucceeded failed", func() {
-			result := runWithCoverage(buildFailed, goConvey, noCoverage, "", "", "", "", nil)
+			result := runWithCoverage(buildFailed, goConvey, noCoverage, "", "", "", "", "-tags=", nil)
 
 			Convey("Then no action should be taken", func() {
 				So(result, ShouldResemble, buildFailed)
@@ -41,7 +41,7 @@ func TestShellCommandComposition(t *testing.T) {
 		})
 
 		Convey("And coverage is not wanted", func() {
-			result := runWithCoverage(buildSucceeded, goConvey, noCoverage, "", "", "", "", nil)
+			result := runWithCoverage(buildSucceeded, goConvey, noCoverage, "", "", "", "", "-tags=", nil)
 
 			Convey("Then no action should be taken", func() {
 				So(result, ShouldResemble, buildSucceeded)
@@ -49,31 +49,31 @@ func TestShellCommandComposition(t *testing.T) {
 		})
 
 		Convey("And the package being tested usees the GoConvey DSL (`convey` package)", func() {
-			result := runWithCoverage(buildSucceeded, goConvey, yesCoverage, "reportsPath", "/directory", "go", "5s", []string{"-arg1", "-arg2"})
+			result := runWithCoverage(buildSucceeded, goConvey, yesCoverage, "reportsPath", "/directory", "go", "5s", "-tags=bob", []string{"-arg1", "-arg2"})
 
 			Convey("The returned command should be well formed (and include the -json flag)", func() {
 				So(result, ShouldResemble, Command{
 					directory:  "/directory",
 					executable: "go",
-					arguments:  []string{"test", "-v", "-coverprofile=reportsPath", "-covermode=set", "-timeout=5s", "-json", "-arg1", "-arg2"},
+					arguments:  []string{"test", "-v", "-coverprofile=reportsPath", "-tags=bob", "-covermode=set", "-timeout=5s", "-json", "-arg1", "-arg2"},
 				})
 			})
 		})
 
 		Convey("And the package being tested does NOT use the GoConvey DSL", func() {
-			result := runWithCoverage(buildSucceeded, noGoConvey, yesCoverage, "reportsPath", "/directory", "go", "1s", []string{"-arg1", "-arg2"})
+			result := runWithCoverage(buildSucceeded, noGoConvey, yesCoverage, "reportsPath", "/directory", "go", "1s", "-tags=bob", []string{"-arg1", "-arg2"})
 
 			Convey("The returned command should be well formed (and NOT include the -json flag)", func() {
 				So(result, ShouldResemble, Command{
 					directory:  "/directory",
 					executable: "go",
-					arguments:  []string{"test", "-v", "-coverprofile=reportsPath", "-covermode=set", "-timeout=1s", "-arg1", "-arg2"},
+					arguments:  []string{"test", "-v", "-coverprofile=reportsPath", "-tags=bob", "-covermode=set", "-timeout=1s", "-arg1", "-arg2"},
 				})
 			})
 		})
 
 		Convey("And the package being tested has been symlinked outside the $GOAPTH", func() {
-			result := runWithCoverage(buildSucceeded, errorGoConvey, yesCoverage, "reportsPath", "/directory", "go", "1s", nil)
+			result := runWithCoverage(buildSucceeded, errorGoConvey, yesCoverage, "reportsPath", "/directory", "go", "1s", "-tags=", nil)
 
 			Convey("The returned command should be the compilation command", func() {
 				So(result, ShouldResemble, buildSucceeded)
@@ -81,25 +81,25 @@ func TestShellCommandComposition(t *testing.T) {
 		})
 
 		Convey("And the package being tested specifies an alternate covermode", func() {
-			result := runWithCoverage(buildSucceeded, noGoConvey, yesCoverage, "reportsPath", "/directory", "go", "1s", []string{"-covermode=atomic"})
+			result := runWithCoverage(buildSucceeded, noGoConvey, yesCoverage, "reportsPath", "/directory", "go", "1s", "-tags=", []string{"-covermode=atomic"})
 
 			Convey("The returned command should allow the alternate value", func() {
 				So(result, ShouldResemble, Command{
 					directory:  "/directory",
 					executable: "go",
-					arguments:  []string{"test", "-v", "-coverprofile=reportsPath", "-timeout=1s", "-covermode=atomic"},
+					arguments:  []string{"test", "-v", "-coverprofile=reportsPath", "-tags=", "-timeout=1s", "-covermode=atomic"},
 				})
 			})
 		})
 
 		Convey("And the package being tested specifies an alternate timeout", func() {
-			result := runWithCoverage(buildSucceeded, noGoConvey, yesCoverage, "reportsPath", "/directory", "go", "1s", []string{"-timeout=5s"})
+			result := runWithCoverage(buildSucceeded, noGoConvey, yesCoverage, "reportsPath", "/directory", "go", "1s", "-tags=", []string{"-timeout=5s"})
 
 			Convey("The returned command should allow the alternate value", func() {
 				So(result, ShouldResemble, Command{
 					directory:  "/directory",
 					executable: "go",
-					arguments:  []string{"test", "-v", "-coverprofile=reportsPath", "-covermode=set", "-timeout=5s"},
+					arguments:  []string{"test", "-v", "-coverprofile=reportsPath", "-tags=", "-covermode=set", "-timeout=5s"},
 				})
 			})
 		})
@@ -108,7 +108,7 @@ func TestShellCommandComposition(t *testing.T) {
 
 	Convey("When attempting to run tests without the coverage flags", t, func() {
 		Convey("And tests already succeeded with coverage", func() {
-			result := runWithoutCoverage(buildSucceeded, coveragePassed, goConvey, "/directory", "go", "1s", []string{"-arg1", "-arg2"})
+			result := runWithoutCoverage(buildSucceeded, coveragePassed, goConvey, "/directory", "go", "1s", "-tags=", []string{"-arg1", "-arg2"})
 
 			Convey("Then no action should be taken", func() {
 				So(result, ShouldResemble, coveragePassed)
@@ -116,7 +116,7 @@ func TestShellCommandComposition(t *testing.T) {
 		})
 
 		Convey("And tests already failed (legitimately) with coverage", func() {
-			result := runWithoutCoverage(buildSucceeded, coverageFailed, goConvey, "/directory", "go", "1s", []string{"-arg1", "-arg2"})
+			result := runWithoutCoverage(buildSucceeded, coverageFailed, goConvey, "/directory", "go", "1s", "-tags=", []string{"-arg1", "-arg2"})
 
 			Convey("Then no action should be taken", func() {
 				So(result, ShouldResemble, coverageFailed)
@@ -124,7 +124,7 @@ func TestShellCommandComposition(t *testing.T) {
 		})
 
 		Convey("And tests already failed (timeout) with coverage", func() {
-			result := runWithoutCoverage(buildSucceeded, coverageFailedTimeout, goConvey, "/directory", "go", "1s", []string{"-arg1", "-arg2"})
+			result := runWithoutCoverage(buildSucceeded, coverageFailedTimeout, goConvey, "/directory", "go", "1s", "-tags=", []string{"-arg1", "-arg2"})
 
 			Convey("Then no action should be taken", func() {
 				So(result, ShouldResemble, coverageFailedTimeout)
@@ -132,7 +132,7 @@ func TestShellCommandComposition(t *testing.T) {
 		})
 
 		Convey("And the build failed earlier", func() {
-			result := runWithoutCoverage(buildFailed, Command{}, goConvey, "/directory", "go", "1s", []string{"-arg1", "-arg2"})
+			result := runWithoutCoverage(buildFailed, Command{}, goConvey, "/directory", "go", "1s", "-tags=", []string{"-arg1", "-arg2"})
 
 			Convey("Then no action should be taken", func() {
 				So(result, ShouldResemble, buildFailed)
@@ -140,7 +140,7 @@ func TestShellCommandComposition(t *testing.T) {
 		})
 
 		Convey("And the goconvey dsl command failed (probably because of symlinks)", func() {
-			result := runWithoutCoverage(buildSucceeded, Command{}, errorGoConvey, "", "", "", nil)
+			result := runWithoutCoverage(buildSucceeded, Command{}, errorGoConvey, "", "", "", "-tags=", nil)
 
 			Convey("Then no action should be taken", func() {
 				So(result, ShouldResemble, errorGoConvey)
@@ -148,37 +148,37 @@ func TestShellCommandComposition(t *testing.T) {
 		})
 
 		Convey("And the package being tested uses the GoConvey DSL (`convey` package)", func() {
-			result := runWithoutCoverage(buildSucceeded, buildSucceeded, goConvey, "/directory", "go", "1s", []string{"-arg1", "-arg2"})
+			result := runWithoutCoverage(buildSucceeded, buildSucceeded, goConvey, "/directory", "go", "1s", "-tags=", []string{"-arg1", "-arg2"})
 
 			Convey("Then the returned command should be well formed (and include the -json flag)", func() {
 				So(result, ShouldResemble, Command{
 					directory:  "/directory",
 					executable: "go",
-					arguments:  []string{"test", "-v", "-timeout=1s", "-json", "-arg1", "-arg2"},
+					arguments:  []string{"test", "-v", "-tags=", "-timeout=1s", "-json", "-arg1", "-arg2"},
 				})
 			})
 		})
 
 		Convey("And the package being tested does NOT use the GoConvey DSL", func() {
-			result := runWithoutCoverage(buildSucceeded, noCoveragePassed, noGoConvey, "/directory", "go", "1s", []string{"-arg1", "-arg2"})
+			result := runWithoutCoverage(buildSucceeded, noCoveragePassed, noGoConvey, "/directory", "go", "1s", "-tags=", []string{"-arg1", "-arg2"})
 
 			Convey("Then the returned command should be well formed (and NOT include the -json flag)", func() {
 				So(result, ShouldResemble, Command{
 					directory:  "/directory",
 					executable: "go",
-					arguments:  []string{"test", "-v", "-timeout=1s", "-arg1", "-arg2"},
+					arguments:  []string{"test", "-v", "-tags=", "-timeout=1s", "-arg1", "-arg2"},
 				})
 			})
 		})
 
 		Convey("And the package being tested specifies an alternate timeout", func() {
-			result := runWithoutCoverage(buildSucceeded, buildSucceeded, noGoConvey, "/directory", "go", "1s", []string{"-timeout=5s"})
+			result := runWithoutCoverage(buildSucceeded, buildSucceeded, noGoConvey, "/directory", "go", "1s", "-tags=", []string{"-timeout=5s"})
 
 			Convey("The returned command should allow the alternate value", func() {
 				So(result, ShouldResemble, Command{
 					directory:  "/directory",
 					executable: "go",
-					arguments:  []string{"test", "-v", "-timeout=5s"},
+					arguments:  []string{"test", "-v", "-tags=", "-timeout=5s"},
 				})
 			})
 		})

--- a/web/server/watch/imperative_shell.go
+++ b/web/server/watch/imperative_shell.go
@@ -17,6 +17,7 @@ type FileSystemItem struct {
 	IsFolder bool
 
 	ProfileDisabled  bool
+	ProfileTags      []string
 	ProfileArguments []string
 }
 

--- a/web/server/watch/integration.go
+++ b/web/server/watch/integration.go
@@ -130,7 +130,7 @@ func (this *Watcher) gather() (folders messaging.Folders, checksum int64) {
 	for _, item := range profileItems {
 		// TODO: don't even bother if the item's size is over a few hundred bytes...
 		contents := ReadContents(item.Path)
-		item.ProfileDisabled, item.ProfileArguments = ParseProfile(contents)
+		item.ProfileDisabled, item.ProfileTags, item.ProfileArguments = ParseProfile(contents)
 	}
 
 	folders = CreateFolders(folderItems)


### PR DESCRIPTION
This allows you to drop build -tags in the .goconvey file and have them correctly used by all the relevant go tool invocations. This is particularly useful for appengine go packages, which invariably need the bogus `+build appengine` build tag.