### PR TITLE
Small change to include files that end in _tests.go as external callers

### DIFF
--- a/convey/gotest/utils.go
+++ b/convey/gotest/utils.go
@@ -23,7 +23,7 @@ func ResolveExternalCaller() (file string, line int, name string) {
 
 	for x := 0; x < callers; x++ {
 		caller_id, file, line, _ = runtime.Caller(x)
-		if strings.HasSuffix(file, "_test.go") {
+		if strings.HasSuffix(file, "_test.go") || strings.HasSuffix(file, "_tests.go") {
 			name = runtime.FuncForPC(caller_id).Name()
 			return
 		}


### PR DESCRIPTION
This change came about because of a use case where the current semantics around resolving
external callers was not ideal.  The use case was for testing interfaces.  In such cases,
the interfaces are typically stored in one package while implementations are stored
in another.  Furthermore, tests written against the interface are stored with the interfaces
but the actual tests that instantiate the implementation and call the interface tests
are stored with the implementations.  The net result of this is that GoConvey would
get confused on who the external caller was AND any files that ended in _test.go stored
with the interfaces were excluded during compilation of the implementations.  This small
change allows files ending in _tests.go to also be candidates for external callers.  The
result is that tests written against interfaces can be stored with the interfaces in
a file that ends with _tests.go and the Go compiler will, therefore, include them when
compiling the implementations...and all is well.