### PR TITLE
Fixes for 1.5

### DIFF
--- a/web/server/parser/packageParser.go
+++ b/web/server/parser/packageParser.go
@@ -11,7 +11,7 @@ import (
 )
 
 var (
-	testNamePattern = regexp.MustCompile("^=== RUN:? (.+)$")
+	testNamePattern = regexp.MustCompile("^=== RUN:? +(.+)$")
 )
 
 func ParsePackageResults(result *contract.PackageResult, rawOutput string) {
@@ -101,10 +101,12 @@ func (self *outputParser) registerTestFunction() {
 }
 func (self *outputParser) recordTestMetadata() {
 	testName := strings.Split(self.line, " ")[2]
-	self.test = self.testMap[testName]
-	self.test.Passed = !strings.HasPrefix(self.line, "--- FAIL: ")
-	self.test.Skipped = strings.HasPrefix(self.line, "--- SKIP: ")
-	self.test.Elapsed = parseTestFunctionDuration(self.line)
+	if test, ok := self.testMap[testName]; ok {
+		self.test = test
+		self.test.Passed = !strings.HasPrefix(self.line, "--- FAIL: ")
+		self.test.Skipped = strings.HasPrefix(self.line, "--- SKIP: ")
+		self.test.Elapsed = parseTestFunctionDuration(self.line)
+	}
 }
 func (self *outputParser) recordPackageMetadata() {
 	if packageFailed(self.line) {

--- a/web/server/parser/package_parser_test.go
+++ b/web/server/parser/package_parser_test.go
@@ -120,10 +120,16 @@ func TestParsePackage_NestedTests_ReturnsPackageResult(t *testing.T) {
 	assertEqual(t, expectedNestedTests, *actual)
 }
 
-func TestParsePacakge_WithExampleFunctions_ReturnsPackageResult(t *testing.T) {
+func TestParsePackage_WithExampleFunctions_ReturnsPackageResult(t *testing.T) {
 	actual := &contract.PackageResult{PackageName: expectedExampleFunctions.PackageName}
 	ParsePackageResults(actual, inputExampleFunctions)
 	assertEqual(t, expectedExampleFunctions, *actual)
+}
+
+func TestParsePackage_Golang15Output_ShouldNotPanic(t *testing.T) {
+	actual := &contract.PackageResult{PackageName: expectedGolang15.PackageName}
+	ParsePackageResults(actual, inputGolang15)
+	assertEqual(t, expectedGolang15, *actual)
 }
 
 func assertEqual(t *testing.T, expected, actual interface{}) {
@@ -752,6 +758,30 @@ var expectedExampleFunctions = contract.PackageResult{
 		contract.TestResult{
 			TestName: "Example_Pass",
 			Elapsed:  0.06,
+			Passed:   true,
+			File:     "",
+			Line:     0,
+			Message:  "",
+			Stories:  []reporting.ScopeResult{},
+		},
+	},
+}
+
+const inputGolang15 = `
+=== RUN   Golang15
+--- PASS: Golang15 (0.00s)
+PASS
+ok  	github.com/smartystreets/goconvey/webserver/examples	0.008s
+`
+
+var expectedGolang15 = contract.PackageResult{
+	PackageName: "github.com/smartystreets/goconvey/webserver/examples",
+	Elapsed:     0.008,
+	Outcome:     contract.Passed,
+	TestResults: []contract.TestResult{
+		contract.TestResult{
+			TestName: "Golang15",
+			Elapsed:  0.00,
 			Passed:   true,
 			File:     "",
 			Line:     0,


### PR DESCRIPTION
This change allows goconvey to execute with current tip. There are two other failures in the test suite that I didn't investigate. I believe they're related to the number of goroutines started to run tests.