### PR TITLE
Add iOS META tag for full screen iOS Safari Home Screen bookmarks

### DIFF
--- a/web/client/index.html
+++ b/web/client/index.html
@@ -2,6 +2,7 @@
 <html>
 	<head>
 		<title>GoConvey</title>
+		<meta name="apple-mobile-web-app-capable" content="yes">
 		<link rel="stylesheet" href="/resources/css/font-awesome.min.css">
 		<link rel="stylesheet" href="/resources/css/tipsy.css">
 		<link rel="stylesheet" href="/resources/css/common.css">


### PR DESCRIPTION
Added iOS meta tag to index.html so that when creating a home screen
shortcut from Safari the browser chrome will be hidden, giving a better
experience for that scenario.
