### PR TITLE
fix flymake (https://github.com/dougm/goflymake)

### DIFF
--- a/web/server/watch/functional_core.go
+++ b/web/server/watch/functional_core.go
@@ -44,7 +44,7 @@ func foundInHiddenDirectory(item *FileSystemItem, root string) bool {
 	return false
 }
 func isHidden(path string) bool {
-	return strings.HasPrefix(path, ".") || strings.HasPrefix(path, "_")
+	return strings.HasPrefix(path, ".") || strings.HasPrefix(path, "_") || strings.HasPrefix(path, "flymake_")
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/web/server/watch/functional_core_test.go
+++ b/web/server/watch/functional_core_test.go
@@ -48,6 +48,18 @@ func TestCategorize(t *testing.T) {
 		},
 		{
 			Root:     "/.hello",
+			Path:     "/.hello/hello/_world.go",
+			Name:     ".world.go",
+			IsFolder: false,
+		},
+		{
+			Root:     "/.hello",
+			Path:     "/.hello/hello/flymake_world.go",
+			Name:     "flymake_world.go",
+			IsFolder: false,
+		},
+		{
+			Root:     "/.hello",
 			Path:     "/.hello/.hello",
 			Name:     ".hello",
 			IsFolder: true,
@@ -96,7 +108,7 @@ func TestCategorize(t *testing.T) {
 
 		folders, profiles, goFiles := Categorize(items, "/.hello", []string{".go"})
 		So(folders, ShouldResemble, fileSystem[:1])
-		So(profiles, ShouldResemble, fileSystem[9:10])
+		So(profiles, ShouldResemble, fileSystem[11:12])
 		So(goFiles, ShouldResemble, fileSystem[2:4])
 	})
 
@@ -112,7 +124,7 @@ func TestCategorize(t *testing.T) {
 
 		folders, profiles, goFiles := Categorize(items, "/.hello", []string{".go", ".tmpl"})
 		So(folders, ShouldResemble, fileSystem[:1])
-		So(profiles, ShouldResemble, fileSystem[9:10])
+		So(profiles, ShouldResemble, fileSystem[11:12])
 		So(goFiles, ShouldResemble, fileSystem[2:5])
 	})
 }


### PR DESCRIPTION
Flymake is a widely used plugin for emacs. It checks regularly the unsaved code for errors. Therefore it creates e.g. a temporary file flymake_foo.go for foo.go. These temporary files trigger goconvey to test aflter almost every keystroke, which makes goconvey useless. This branch fixes it by ignoring flymake_* flies. It is only a very minimal patch but a welcome fix for the emacs users.