### PR TITLE
Exclude build failures from coverage

### DIFF
--- a/web/client/resources/js/goconvey.js
+++ b/web/client/resources/js/goconvey.js
@@ -561,9 +561,7 @@ function process(data, status, jqxhr)
 			current().failedBuilds.push(pkg);
 			continue;
 		}
-
-
-		if (pkg.Outcome == "no go code")
+		else if (pkg.Outcome == "no go code")
 			packages.nogofiles.push(pkg);
 		else if (pkg.Outcome == "no test files")
 			packages.notestfiles.push(pkg);


### PR DESCRIPTION
Don't include package in coverage stats if build failed. Coverage will then only reflect lines covered by tests that actually ran.