### PR TITLE
Extract low level loop to helper function

### DIFF
--- a/goconvey.go
+++ b/goconvey.go
@@ -80,16 +80,27 @@ func main() {
 func runTestOnUpdates(queue chan messaging.Folders, executor contract.Executor, server contract.Server) {
 	for update := range queue {
 		log.Println("Received request from watcher to execute tests...")
-		root := ""
-		packages := []*contract.Package{}
-		for _, folder := range update {
-			root = folder.Root
-			hasImportCycle := testFilesImportTheirOwnPackage(folder.Path)
-			packages = append(packages, contract.NewPackage(folder, hasImportCycle))
-		}
+		root, packages := extractRoot(update), extractPackages(update)
 		output := executor.ExecuteTests(packages)
 		server.ReceiveUpdate(root, output)
 	}
+}
+
+func extractPackages(folderList messaging.Folders) []*contract.Package {
+	packageList := []*contract.Package{}
+	for _, folder := range folderList {
+		hasImportCycle := testFilesImportTheirOwnPackage(folder.Path)
+		packageList = append(packageList, contract.NewPackage(folder, hasImportCycle))
+	}
+	return packageList
+}
+
+func extractRoot(folders messaging.Folders) string {
+	root := ""
+	for _, f := range folders {
+		root = f.Root
+	}
+	return root
 }
 
 // This method exists because of a bug in the go cover tool that

--- a/goconvey.go
+++ b/goconvey.go
@@ -80,8 +80,9 @@ func main() {
 func runTestOnUpdates(queue chan messaging.Folders, executor contract.Executor, server contract.Server) {
 	for update := range queue {
 		log.Println("Received request from watcher to execute tests...")
-		root, packages := extractRoot(update), extractPackages(update)
+		packages := extractPackages(update)
 		output := executor.ExecuteTests(packages)
+		root := extractRoot(update, packages)
 		server.ReceiveUpdate(root, output)
 	}
 }
@@ -95,12 +96,10 @@ func extractPackages(folderList messaging.Folders) []*contract.Package {
 	return packageList
 }
 
-func extractRoot(folders messaging.Folders) string {
-	root := ""
-	for _, f := range folders {
-		root = f.Root
-	}
-	return root
+func extractRoot(folderList messaging.Folders, packageList []*contract.Package) string {
+	path := packageList[0].Path
+	folder := folderList[path]
+	return folder.Root
 }
 
 // This method exists because of a bug in the go cover tool that


### PR DESCRIPTION
Sorry. The sudden change in abstraction, from readable high to detailed low level inner loop was jarring. Couldn't help it. I refactored the out of place low level inner loop into a helper function. 7 lines now replaced with 1 thats readable and does the same thing.