### PR TITLE
Remove height limit on errors

### DIFF
--- a/web/client/resources/css/common.css
+++ b/web/client/resources/css/common.css
@@ -382,6 +382,7 @@ footer .server-down {
 	font-size: 12px;
 	line-height: 1.25em;
 	overflow-y: auto;
+	white-space: pre-wrap;
 	font-family: 'Menlo', monospace;
 }
 

--- a/web/client/resources/css/common.css
+++ b/web/client/resources/css/common.css
@@ -381,9 +381,7 @@ footer .server-down {
 	padding: 10px;
 	font-size: 12px;
 	line-height: 1.25em;
-	max-height: 150px;
 	overflow-y: auto;
-	white-space: pre;
 	font-family: 'Menlo', monospace;
 }
 


### PR DESCRIPTION
This also remove the auto-wrap. The output is now far easier to read, especially for verbose errors.

A preview, on top is the old version, below the new.
<img width="710" alt="preview" src="https://cloud.githubusercontent.com/assets/3159064/10564384/43c07b94-75b2-11e5-8ee0-1beb958ff54d.png">
