### PR TITLE
added excluded directory functionality

### DIFF
--- a/goconvey.go
+++ b/goconvey.go
@@ -41,6 +41,7 @@ func flags() {
 	flag.IntVar(&depth, "depth", -1, "The directory scanning depth. If -1, scan infinitely deep directory structures. 0: scan working directory. 1+: Scan into nested directories, limited to value. (default: -1)")
 	flag.StringVar(&timeout, "timeout", "0", "The test execution timeout if none is specified in the *.goconvey file (default is '0', which is the same as not providing this option).")
 	flag.StringVar(&watchedSuffixes, "watchedSuffixes", ".go", "A comma separated list of file suffixes to watch for modifications (default: .go).")
+	flag.StringVar(&excludedDirs, "excludedDirs", "vendor,node_modules", "A comma separated list of directories that will be excluded from being watched")
 	flag.StringVar(&workDir, "workDir", "", "set goconvey working directory (default current directory)")
 
 	log.SetOutput(os.Stdout)
@@ -63,7 +64,8 @@ func main() {
 
 	watcherInput := make(chan messaging.WatcherCommand)
 	watcherOutput := make(chan messaging.Folders)
-	watcher := watch.NewWatcher(working, depth, nap, watcherInput, watcherOutput, watchedSuffixes)
+	excludedDirItems := strings.Split(excludedDirs, `,`)
+	watcher := watch.NewWatcher(working, depth, nap, watcherInput, watcherOutput, watchedSuffixes, excludedDirItems)
 
 	parser := parser.NewParser(parser.ParsePackageResults)
 	tester := executor.NewConcurrentTester(shell)
@@ -261,6 +263,7 @@ var (
 	depth           int
 	timeout         string
 	watchedSuffixes string
+	excludedDirs    string
 
 	static  string
 	reports string

--- a/web/server/watch/imperative_shell.go
+++ b/web/server/watch/imperative_shell.go
@@ -24,13 +24,20 @@ type FileSystemItem struct {
 
 ///////////////////////////////////////////////////////////////////////////////
 
-func YieldFileSystemItems(root string) chan *FileSystemItem {
+func YieldFileSystemItems(root string, excludedDirs []string) chan *FileSystemItem {
 	items := make(chan *FileSystemItem)
 
 	go func() {
 		filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
 			if err != nil {
 				return filepath.SkipDir
+			}
+
+			basePath := filepath.Base(path)
+			for _, item := range excludedDirs {
+				if item == basePath && info.IsDir() && item != "" && basePath != "" {
+					return filepath.SkipDir
+				}
 			}
 
 			items <- &FileSystemItem{

--- a/web/server/watch/integration.go
+++ b/web/server/watch/integration.go
@@ -19,6 +19,7 @@ type Watcher struct {
 	paused          bool
 	stopped         bool
 	watchSuffixes   []string
+	excludedDirs    []string
 
 	input  chan messaging.WatcherCommand
 	output chan messaging.Folders
@@ -27,7 +28,7 @@ type Watcher struct {
 }
 
 func NewWatcher(rootFolder string, folderDepth int, nap time.Duration,
-	input chan messaging.WatcherCommand, output chan messaging.Folders, watchSuffixes string) *Watcher {
+	input chan messaging.WatcherCommand, output chan messaging.Folders, watchSuffixes string, excludedDirs []string) *Watcher {
 
 	return &Watcher{
 		nap:           nap,
@@ -36,6 +37,7 @@ func NewWatcher(rootFolder string, folderDepth int, nap time.Duration,
 		input:         input,
 		output:        output,
 		watchSuffixes: strings.Split(watchSuffixes, ","),
+		excludedDirs:  excludedDirs,
 
 		ignoredFolders: make(map[string]struct{}),
 	}
@@ -124,7 +126,7 @@ func (this *Watcher) scan() {
 }
 
 func (this *Watcher) gather() (folders messaging.Folders, checksum int64) {
-	items := YieldFileSystemItems(this.rootFolder)
+	items := YieldFileSystemItems(this.rootFolder, this.excludedDirs)
 	folderItems, profileItems, goFileItems := Categorize(items, this.rootFolder, this.watchSuffixes)
 
 	for _, item := range profileItems {

--- a/web/server/watch/integration_test.go
+++ b/web/server/watch/integration_test.go
@@ -66,7 +66,8 @@ func TestWatcher(t *testing.T) {
 	Convey("Subject: Watcher operations", t, func() {
 		input := make(chan messaging.WatcherCommand)
 		output := make(chan messaging.Folders)
-		watcher := NewWatcher(root, -1, time.Millisecond, input, output, ".go")
+		excludedDirs := []string{}
+		watcher := NewWatcher(root, -1, time.Millisecond, input, output, ".go", excludedDirs)
 
 		go watcher.Listen()
 


### PR DESCRIPTION
A flag can be passed to goconvey to specify directories to be excluded
from being watched.  The default skipped directories are vendor and
node_modules.