### PR TITLE
Add env var to configure goconvey reporter.

### DIFF
--- a/convey/init.go
+++ b/convey/init.go
@@ -34,14 +34,19 @@ func noStoryFlagProvided() bool {
 }
 
 func buildReporter() reporting.Reporter {
+	selectReporter := os.Getenv("GOCONVEY_REPORTER")
+
 	switch {
 	case testReporter != nil:
 		return testReporter
-	case json:
+	case json || selectReporter == "json":
 		return reporting.BuildJsonReporter()
-	case silent:
+	case silent || selectReporter == "silent":
 		return reporting.BuildSilentReporter()
-	case story:
+	case selectReporter == "dot":
+		// Story is turned on when verbose is set, so we need to check for dot reporter first.
+		return reporting.BuildDotReporter()
+	case story || selectReporter == "story":
 		return reporting.BuildStoryReporter()
 	default:
 		return reporting.BuildDotReporter()


### PR DESCRIPTION
Provide a way to set the reporter using other methods than simply
command line flags. Passing flags to goconvey is iffy when working
with mixed tests, not all of which might use goconvey
(and unrecognized flags cause the test binary to fail)

---

Scenario:
 * Have some test suites (from companion packages, etc) not using GoConvey
 * running tests in a remote console CI environment which doesn't pass utf-8 back well, so I get back a bunch of question marks. 
* Want to use `-v` to show detailed testing, but also want `-story=false` to disable the dot reporter, but this doesn't work out because any packages not using goconvey will fail with invalid flag passed

