### PR TITLE
Support screen-256color

### DIFF
--- a/convey/reporting/init.go
+++ b/convey/reporting/init.go
@@ -1,14 +1,13 @@
 package reporting
 
 import (
-	"fmt"
 	"os"
 	"runtime"
 	"strings"
 )
 
 func init() {
-	if !isXterm() {
+	if !is256Terminal() {
 		monochrome()
 	}
 
@@ -83,10 +82,8 @@ func monochrome() {
 	greenColor, yellowColor, redColor, resetColor = "", "", "", ""
 }
 
-func isXterm() bool {
-	env := fmt.Sprintf("%v", os.Environ())
-	return strings.Contains(env, " TERM=isXterm") ||
-		strings.Contains(env, " TERM=xterm")
+func is256Terminal() bool {
+	return strings.Contains(os.Getenv("TERM"), "256")
 }
 
 // This interface allows us to pass the *testing.T struct

--- a/convey/reporting/init.go
+++ b/convey/reporting/init.go
@@ -7,7 +7,7 @@ import (
 )
 
 func init() {
-	if !is256Terminal() {
+	if !isColorableTerminal() {
 		monochrome()
 	}
 
@@ -82,8 +82,8 @@ func monochrome() {
 	greenColor, yellowColor, redColor, resetColor = "", "", "", ""
 }
 
-func is256Terminal() bool {
-	return strings.Contains(os.Getenv("TERM"), "256")
+func isColorableTerminal() bool {
+	return strings.Contains(os.Getenv("TERM"), "color")
 }
 
 // This interface allows us to pass the *testing.T struct


### PR DESCRIPTION
Using tmux, `$TERM` is `screen-256color` as default.
In `screen-256color`, that can display colored output but go-convey allows `xterm-*` only.
So I fixed `isXterm` function to `isColorableTerminal` that allows any `$TERM` containing "color".