### PR TITLE
prefix "convey" added to all command line flags #386

### DIFF
--- a/convey/init.go
+++ b/convey/init.go
@@ -18,9 +18,9 @@ func init() {
 }
 
 func declareFlags() {
-	flag.BoolVar(&json, "json", false, "When true, emits results in JSON blocks. Default: 'false'")
-	flag.BoolVar(&silent, "silent", false, "When true, all output from GoConvey is suppressed.")
-	flag.BoolVar(&story, "story", false, "When true, emits story output, otherwise emits dot output. When not provided, this flag mirros the value of the '-test.v' flag")
+	flag.BoolVar(&json, "convey-json", false, "When true, emits results in JSON blocks. Default: 'false'")
+	flag.BoolVar(&silent, "convey-silent", false, "When true, all output from GoConvey is suppressed.")
+	flag.BoolVar(&story, "convey-story", false, "When true, emits story output, otherwise emits dot output. When not provided, this flag mirros the value of the '-test.v' flag")
 
 	if noStoryFlagProvided() {
 		story = verboseEnabled

--- a/web/server/system/shell.go
+++ b/web/server/system/shell.go
@@ -77,7 +77,7 @@ func runWithCoverage(compile, goconvey Command, coverage bool, reportPath, direc
 	}
 
 	if strings.Contains(goconvey.Output, goconveyDSLImport) {
-		arguments = append(arguments, "-json")
+		arguments = append(arguments, "-convey-json")
 	}
 
 	arguments = append(arguments, customArguments...)
@@ -110,7 +110,7 @@ func runWithoutCoverage(compile, withCoverage, goconvey Command, directory, gobi
 	}
 
 	if strings.Contains(goconvey.Output, goconveyDSLImport) {
-		arguments = append(arguments, "-json")
+		arguments = append(arguments, "-convey-json")
 	}
 	arguments = append(arguments, customArguments...)
 	return NewCommand(directory, gobin, arguments...)

--- a/web/server/system/shell_test.go
+++ b/web/server/system/shell_test.go
@@ -55,7 +55,7 @@ func TestShellCommandComposition(t *testing.T) {
 				So(result, ShouldResemble, Command{
 					directory:  "/directory",
 					executable: "go",
-					arguments:  []string{"test", "-v", "-coverprofile=reportsPath", "-tags=bob", "-covermode=set", "-timeout=5s", "-json", "-arg1", "-arg2"},
+					arguments:  []string{"test", "-v", "-coverprofile=reportsPath", "-tags=bob", "-covermode=set", "-timeout=5s", "-convey-json", "-arg1", "-arg2"},
 				})
 			})
 		})
@@ -154,7 +154,7 @@ func TestShellCommandComposition(t *testing.T) {
 				So(result, ShouldResemble, Command{
 					directory:  "/directory",
 					executable: "go",
-					arguments:  []string{"test", "-v", "-tags=", "-timeout=1s", "-json", "-arg1", "-arg2"},
+					arguments:  []string{"test", "-v", "-tags=", "-timeout=1s", "-convey-json", "-arg1", "-arg2"},
 				})
 			})
 		})


### PR DESCRIPTION
I believe I've fixed all places you mentioned in #386 , but could you take a look?