### PR TITLE
Adding Given/When/Then aliases to Convey()

### DIFF
--- a/convey/doc.go
+++ b/convey/doc.go
@@ -33,6 +33,31 @@ type C interface {
 	Printf(format string, items ...interface{}) (int, error)
 }
 
+func prefixConveyCallWith(prefix string, items ...interface{}) {
+	if len(items) > 0 {
+		s, ok := items[0].(string)
+		if ok {
+			items[0] = prefix + " " + s
+		}
+	}
+	Convey(items...)
+}
+
+// Given("a thing", ...) is an alias to Convey("Given a thing", ...)
+func Given(items ...interface{}) {
+	prefixConveyCallWith("Given", items...)
+}
+
+// When("something happens", ...) is an alias to Convey("When something happens", ...)
+func When(items ...interface{}) {
+	prefixConveyCallWith("When", items...)
+}
+
+// Then("something happens", ...) is an alias to Convey("Then something happens", ...)
+func Then(items ...interface{}) {
+	prefixConveyCallWith("Then", items...)
+}
+
 // Convey is the method intended for use when declaring the scopes of
 // a specification. Each scope has a description and a func() which may contain
 // other calls to Convey(), Reset() or Should-style assertions. Convey calls can


### PR DESCRIPTION
Simple syntactic sugar to express Convey() calls using Given/When/Then functions. 

The idea is this can make the intent clearer and reduce the line length for Convey calls which can become quite verbose.

Given("something",...) == Convey("Given something", ...)
When("something happens", ...) == Convey("When something happens", ...)
Then("something happens", ...) == Convey("Then something happens", ...)

e.g. 
```
func TestBowlingGameScoring(t *testing.T) {
	Given("a fresh score card", t, func() {
		game := NewGame()

		When("all gutter balls are thrown", func() {
			game.rollMany(20, 0)

			Then("the score should be zero", func() {
				So(game.Score(), ShouldEqual, 0)
			})
		})
	}
}
```