### PR TITLE
Exit if port is in use instead of allowing a panic

### DIFF
--- a/goconvey.go
+++ b/goconvey.go
@@ -158,6 +158,9 @@ func createListener() net.Listener {
 	if err != nil {
 		log.Println(err)
 	}
+	if l == nil {
+		os.Exit(1)
+	}
 	return l
 }
 


### PR DESCRIPTION
Follow-up to #412. No real functionality change, just prevents a panic in the output.