### PR TITLE
Add locking to report statistics.

### DIFF
--- a/convey/reporting/statistics.go
+++ b/convey/reporting/statistics.go
@@ -1,12 +1,18 @@
 package reporting
 
-import "fmt"
+import (
+	"fmt"
+	"sync"
+)
 
 func (self *statistics) BeginStory(story *StoryReport) {}
 
 func (self *statistics) Enter(scope *ScopeReport) {}
 
 func (self *statistics) Report(report *AssertionResult) {
+	self.Lock()
+	defer self.Unlock()
+
 	if !self.failing && report.Failure != "" {
 		self.failing = true
 	}
@@ -23,25 +29,36 @@ func (self *statistics) Report(report *AssertionResult) {
 func (self *statistics) Exit() {}
 
 func (self *statistics) EndStory() {
+	self.Lock()
+	defer self.Unlock()
+
 	if !self.suppressed {
-		self.PrintSummary()
+		self.printSummaryLocked()
 	}
 }
 
 func (self *statistics) Suppress() {
+	self.Lock()
+	defer self.Unlock()
 	self.suppressed = true
 }
 
 func (self *statistics) PrintSummary() {
-	self.reportAssertions()
-	self.reportSkippedSections()
-	self.completeReport()
+	self.Lock()
+	defer self.Unlock()
+	self.printSummaryLocked()
 }
-func (self *statistics) reportAssertions() {
-	self.decideColor()
+
+func (self *statistics) printSummaryLocked() {
+	self.reportAssertionsLocked()
+	self.reportSkippedSectionsLocked()
+	self.completeReportLocked()
+}
+func (self *statistics) reportAssertionsLocked() {
+	self.decideColorLocked()
 	self.out.Print("\n%d total %s", self.total, plural("assertion", self.total))
 }
-func (self *statistics) decideColor() {
+func (self *statistics) decideColorLocked() {
 	if self.failing && !self.erroring {
 		fmt.Print(yellowColor)
 	} else if self.erroring {
@@ -50,13 +67,13 @@ func (self *statistics) decideColor() {
 		fmt.Print(greenColor)
 	}
 }
-func (self *statistics) reportSkippedSections() {
+func (self *statistics) reportSkippedSectionsLocked() {
 	if self.skipped > 0 {
 		fmt.Print(yellowColor)
 		self.out.Print(" (one or more sections skipped)")
 	}
 }
-func (self *statistics) completeReport() {
+func (self *statistics) completeReportLocked() {
 	fmt.Print(resetColor)
 	self.out.Print("\n")
 	self.out.Print("\n")
@@ -73,6 +90,8 @@ func NewStatisticsReporter(out *Printer) *statistics {
 }
 
 type statistics struct {
+	sync.Mutex
+
 	out        *Printer
 	total      int
 	failing    bool


### PR DESCRIPTION
This fixes #234, the immediate data race issue, by locking around the
members of the global statistics struct. It doesn't address the issue of
tests stomping on each others' colors, indentation, and other output.