### PR TITLE
Fix #406 - Settings for notify by a given level

### DIFF
--- a/web/client/index.html
+++ b/web/client/index.html
@@ -60,7 +60,7 @@
 				<hr class="clear">
 
 
-				<div class="expandable settings">
+				<div class="expandable settings settings-general">
 					<div class="container">
 						<div class="setting">
 							<div class="setting-meta">
@@ -117,6 +117,34 @@
 							<div class="summary">{{overall.status.text|upcase}}<br>{{overall.passed}}/{{overall.assertions}} pass<br>{{overall.failures}} fail, {{overall.skipped}} skip</div>
 						</div>
 					</script>
+				</div>
+
+				<div class="expandable settings settings-notification">
+					<div class="container">
+						<div class="setting">
+							<div class="setting-meta">
+								Notifications
+							</div>
+							<div class="setting-val">
+								<ol class="enum" id="notification">
+									<li data-notification="true">On</li>
+									<li data-notification="false">Off</li>
+								</ol>
+							</div>
+						</div>
+						<div class="setting">
+							<div class="setting-meta">
+								Level
+							</div>
+							<div class="setting-val">
+								<ol class="enum" id="notification-level">
+									<li data-notification-level=".*">Always</li>
+									<li data-notification-level="fail|panic">Fail or Panic</li>
+									<li data-notification-level="ok">Success Only</li>
+								</ol>
+							</div>
+						</div>
+					</div>
 				</div>
 
 


### PR DESCRIPTION
Added configuration to notifications based on test result status as was discussed in issue #406 

Screen-capture Preview:
![goconvey-notification-settings](https://cloud.githubusercontent.com/assets/419608/14156966/a997d20c-f68e-11e5-9975-9ebe3f044f1c.gif)
 