### PR TITLE
Added: debug output messages more customizable by providing a level (…

### DIFF
--- a/web/client/index.html
+++ b/web/client/index.html
@@ -90,8 +90,9 @@
 							</div>
 							<div class="setting-val">
 								<ol class="enum" id="show-debug-output">
-									<li data-show-debug-output="show">Show</li>
-									<li data-show-debug-output="hide">Hide</li>
+									<li data-show-debug-output="show">All</li>
+									<li data-show-debug-output="fail">Failed</li>
+									<li data-show-debug-output="hide">None</li>
 								</ol>
 							</div>
 						</div>

--- a/web/client/resources/js/goconvey.js
+++ b/web/client/resources/js/goconvey.js
@@ -158,10 +158,7 @@ function wireup()
 	{
 		var newSetting = $(this).data('show-debug-output');
 		save('show-debug-output', newSetting);
-		if (newSetting === "show")
-			$('.story-line-desc .message').show();
-		else
-			$('.story-line-desc .message').hide();
+		setDebugOutputUI(newSetting);
 	});
 	$('.enum#ui-effects').on('click', 'li:not(.sel)', function()
 	{
@@ -430,6 +427,22 @@ function setTooltips()
 			if(!$(this).tipsy(true))
 				$(this).tipsy(tips[key]);
 		});
+	}
+}
+
+function setDebugOutputUI(newSetting){
+	var $storyLine = $('.story-line');
+	switch(newSetting) {
+		case 'hide':
+			$('.message', $storyLine).hide();
+			break;
+		case 'fail':
+			$('.message', $storyLine.not('.fail, .panic')).hide();
+			$('.message', $storyLine.filter('.fail, .panic')).show();
+			break;
+		default:
+			$('.message', $storyLine).show();
+			break;
 	}
 }
 
@@ -913,8 +926,8 @@ function renderFrame(frame)
 
 	$('.history .item').removeClass('selected');
 
-	if (get('show-debug-output') === "hide")
-		$('.story-line-desc .message').hide();
+
+	setDebugOutputUI(get('show-debug-output'));
 
 	log("Rendering finished");
 }


### PR DESCRIPTION
…All, None, Failed)

Sometimes the fail / panic views are very noisy with stack info and I really just want to see the debug output.  This PR enables a feature similar to #406 where the client UI is expanded to be allow more than show/hide of debug messages.  Under the general settings, show and hide for logs is still available(now labeled "all" and "none") but also includes "failed" which will show debug log messages for failed and panic test results.

![debug-output-options](https://cloud.githubusercontent.com/assets/419608/15224021/e1a1306a-183c-11e6-8f7a-b7a4b9f6f58d.png)
