### PR TITLE
ignore flycheck files

### DIFF
--- a/web/server/watch/functional_core.go
+++ b/web/server/watch/functional_core.go
@@ -44,7 +44,7 @@ func foundInHiddenDirectory(item *FileSystemItem, root string) bool {
 	return false
 }
 func isHidden(path string) bool {
-	return strings.HasPrefix(path, ".") || strings.HasPrefix(path, "_") || strings.HasPrefix(path, "flymake_")
+	return strings.HasPrefix(path, ".") || strings.HasPrefix(path, "_") || strings.HasPrefix(path, "flymake_") || strings.HasPrefix(path, "flycheck_")
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/web/server/watch/functional_core_test.go
+++ b/web/server/watch/functional_core_test.go
@@ -60,6 +60,12 @@ func TestCategorize(t *testing.T) {
 		},
 		{
 			Root:     "/.hello",
+			Path:     "/.hello/hello/flycheck_world.go",
+			Name:     "flycheck_world.go",
+			IsFolder: false,
+		},
+		{
+			Root:     "/.hello",
 			Path:     "/.hello/.hello",
 			Name:     ".hello",
 			IsFolder: true,


### PR DESCRIPTION
The change allows watcher to ignore `flycheck_`-prefixed files.
Integration tests also seem to fail on master branch for some reason.