### PR TITLE
Parse test duration correctly for >= go 1.5

### DIFF
--- a/web/server/parser/package_parser_test.go
+++ b/web/server/parser/package_parser_test.go
@@ -769,7 +769,7 @@ var expectedExampleFunctions = contract.PackageResult{
 
 const inputGolang15 = `
 === RUN   Golang15
---- PASS: Golang15 (0.00s)
+--- PASS: Golang15 (0.01s)
 PASS
 ok  	github.com/smartystreets/goconvey/webserver/examples	0.008s
 `
@@ -781,7 +781,7 @@ var expectedGolang15 = contract.PackageResult{
 	TestResults: []contract.TestResult{
 		contract.TestResult{
 			TestName: "Golang15",
-			Elapsed:  0.00,
+			Elapsed:  0.01,
 			Passed:   true,
 			File:     "",
 			Line:     0,

--- a/web/server/parser/util.go
+++ b/web/server/parser/util.go
@@ -9,10 +9,17 @@ import (
 // parseTestFunctionDuration parses the duration in seconds as a float64
 // from a line of go test output that looks something like this:
 // --- PASS: TestOldSchool_PassesWithMessage (0.03 seconds)
+//
+// For Go1.5 and greater the test output looks something like this:
+// --- PASS: TestOldSchool_PassesWithMessage (0.03s)
 func parseTestFunctionDuration(line string) float64 {
 	line = strings.Replace(line, "(", "", 1)
 	fields := strings.Split(line, " ")
-	return parseDurationInSeconds(fields[3]+"s", 2)
+	timeStr := fields[3]+"s"
+	if strings.HasSuffix(timeStr, "s)s") {
+		timeStr = timeStr[:len(timeStr)-2]
+	}
+	return parseDurationInSeconds(timeStr, 2)
 }
 
 func parseDurationInSeconds(raw string, precision int) float64 {


### PR DESCRIPTION
Currently parsing test durations is broken for go 1.5 and above. All test durations are currently reported as 0.00 seconds. This pull request contains a small fix.