### PR TITLE
Improve performance by skipping hidden dirs

### DIFF
--- a/web/server/watch/imperative_shell.go
+++ b/web/server/watch/imperative_shell.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -30,6 +31,10 @@ func YieldFileSystemItems(root string, excludedDirs []string) chan *FileSystemIt
 	go func() {
 		filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
 			if err != nil {
+				return filepath.SkipDir
+			}
+
+			if info.IsDir() && strings.HasPrefix(info.Name(), ".") {
 				return filepath.SkipDir
 			}
 


### PR DESCRIPTION
This PR skips directories starting with `.` to dramatically improve performance if such directories are present. It's a small change but makes a huge impact when there's a directory (such as artifacts from a build tool -- in my case Wercker -- as a hidden directories in the working dir).

Profiled using [pkg/profile](https://github.com/pkg/profile):

**Before**
```
$ go tool pprof --text ./goconvey /var/folders/8m/dzjlyrtd3vx3hb0mwfxgswm80000gn/T/profile152855215/cpu.pprof
42.83s of 43.63s total (98.17%)
Dropped 105 nodes (cum <= 0.22s)
      flat  flat%   sum%        cum   cum%
    14.42s 33.05% 33.05%     14.42s 33.05%  syscall.Syscall
     9.10s 20.86% 53.91%      9.11s 20.88%  syscall.Syscall6
     6.57s 15.06% 68.97%      6.57s 15.06%  runtime.mach_semaphore_wait
     6.48s 14.85% 83.82%      6.48s 14.85%  runtime.mach_semaphore_signal
     5.25s 12.03% 95.85%      5.25s 12.03%  runtime.usleep
     0.50s  1.15% 97.00%      0.50s  1.15%  path/filepath.Clean
     0.27s  0.62% 97.62%      0.27s  0.62%  runtime.memmove
     0.11s  0.25% 97.87%      0.24s  0.55%  runtime.scanobject
     0.05s  0.11% 97.98%     11.52s 26.40%  runtime.findrunnable
     0.03s 0.069% 98.05%      0.26s   0.6%  runtime.gcFlushBgCredit
     0.01s 0.023% 98.07%      5.21s 11.94%  github.com/smartystreets/goconvey/web/server/watch.YieldFileSystemItems.func1.1
     0.01s 0.023% 98.10%      1.02s  2.34%  runtime.gcDrain
     0.01s 0.023% 98.12%      6.49s 14.88%  runtime.notewakeup
     0.01s 0.023% 98.14%      4.64s 10.63%  runtime.runqgrab
     0.01s 0.023% 98.17%      6.70s 15.36%  runtime.semasleep.func1
         0     0% 98.17%      0.59s  1.35%  github.com/smartystreets/goconvey/web/server/watch.(*Watcher).Listen
         0     0% 98.17%      0.59s  1.35%  github.com/smartystreets/goconvey/web/server/watch.(*Watcher).gather
         0     0% 98.17%      0.59s  1.35%  github.com/smartystreets/goconvey/web/server/watch.(*Watcher).scan
         0     0% 98.17%      0.58s  1.33%  github.com/smartystreets/goconvey/web/server/watch.Categorize
         0     0% 98.17%     29.09s 66.67%  github.com/smartystreets/goconvey/web/server/watch.YieldFileSystemItems.func1
         0     0% 98.17%      0.49s  1.12%  github.com/smartystreets/goconvey/web/server/watch.foundInHiddenDirectory
         0     0% 98.17%      1.76s  4.03%  os.(*File).Close
         0     0% 98.17%      9.20s 21.09%  os.(*File).Readdirnames
         0     0% 98.17%      9.20s 21.09%  os.(*File).readdirnames
         0     0% 98.17%      1.76s  4.03%  os.(*file).close
         0     0% 98.17%     10.53s 24.13%  os.Lstat
...
```

**After**
```
$ go tool pprof --text ./goconvey /var/folders/8m/dzjlyrtd3vx3hb0mwfxgswm80000gn/T/profile075756739/cpu.pprof
410ms of 410ms total (  100%)
      flat  flat%   sum%        cum   cum%
     100ms 24.39% 24.39%      100ms 24.39%  syscall.Syscall6
      90ms 21.95% 46.34%       90ms 21.95%  runtime.usleep
      80ms 19.51% 65.85%       80ms 19.51%  runtime.mach_semaphore_signal
      60ms 14.63% 80.49%       60ms 14.63%  runtime.mach_semaphore_wait
      60ms 14.63% 95.12%       60ms 14.63%  syscall.Syscall
      10ms  2.44% 97.56%       10ms  2.44%  runtime.runqget
      10ms  2.44%   100%       10ms  2.44%  syscall.ParseDirent
         0     0%   100%       20ms  4.88%  github.com/smartystreets/goconvey/web/server/watch.(*Watcher).Listen
         0     0%   100%      230ms 56.10%  github.com/smartystreets/goconvey/web/server/watch.YieldFileSystemItems.func1
         0     0%   100%       60ms 14.63%  github.com/smartystreets/goconvey/web/server/watch.YieldFileSystemItems.func1.1
         0     0%   100%       20ms  4.88%  os.(*File).Close
         0     0%   100%      110ms 26.83%  os.(*File).Readdirnames
         0     0%   100%      110ms 26.83%  os.(*File).readdirnames
         0     0%   100%       20ms  4.88%  os.(*file).close
         0     0%   100%       20ms  4.88%  os.Lstat
...
```

Before:
<img width="712" alt="screen shot 2016-09-28 at 22 20 28" src="https://cloud.githubusercontent.com/assets/540683/18930799/cbf556f6-85c9-11e6-93e8-6f15cd005e44.png">

After:
<img width="713" alt="screen shot 2016-09-28 at 22 23 22" src="https://cloud.githubusercontent.com/assets/540683/18930903/3acff9dc-85ca-11e6-9b5d-af39a1719e33.png">