### PR TITLE
Built-in support for GB based projects (getgb.io)

### DIFF
--- a/convey/gb.go
+++ b/convey/gb.go
@@ -1,0 +1,49 @@
+package convey
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func SetGBPath(workDir string) {
+	root, err := findProjectroot(workDir)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	goPath := strings.Join([]string{
+		root,
+		filepath.Join(root, "vendor")}, ":")
+
+	err = os.Setenv("GOPATH", goPath)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	log.Printf("Enabling GB compatibility: GOPATH set to '%s'\n", goPath)
+}
+
+// findProjectroot works upwards from path seaching for the
+// src/ directory which identifies the project root.
+func findProjectroot(path string) (string, error) {
+	if path == "" {
+		return "", errors.New("project root is blank")
+	}
+	start := path
+	for path != filepath.Dir(path) {
+		root := filepath.Join(path, "src")
+		if _, err := os.Stat(root); err != nil {
+			if os.IsNotExist(err) {
+				path = filepath.Dir(path)
+				continue
+			}
+			return "", err
+		}
+		return path, nil
+	}
+	return "", fmt.Errorf(`could not find project root in "%s" or its parents`, start)
+}

--- a/goconvey.go
+++ b/goconvey.go
@@ -19,6 +19,7 @@ import (
 
 	"go/build"
 
+	"github.com/smartystreets/goconvey/convey"
 	"github.com/smartystreets/goconvey/web/server/api"
 	"github.com/smartystreets/goconvey/web/server/contract"
 	"github.com/smartystreets/goconvey/web/server/executor"
@@ -45,6 +46,7 @@ func flags() {
 	flag.StringVar(&excludedDirs, "excludedDirs", "vendor,node_modules", "A comma separated list of directories that will be excluded from being watched")
 	flag.StringVar(&workDir, "workDir", "", "set goconvey working directory (default current directory)")
 	flag.BoolVar(&autoLaunchBrowser, "launchBrowser", true, "toggle auto launching of browser (default: true)")
+	flag.BoolVar(&gbProject, "gb", false, "use gb (getgb.io) environment src/ and vendor/src")
 
 	log.SetOutput(os.Stdout)
 	log.SetFlags(log.LstdFlags | log.Lshortfile)
@@ -63,6 +65,10 @@ func main() {
 	working := getWorkDir()
 	cover = coverageEnabled(cover, reports)
 	shell := system.NewShell(gobin, reports, cover, timeout)
+
+	if gbProject {
+		convey.SetGBPath(working)
+	}
 
 	watcherInput := make(chan messaging.WatcherCommand)
 	watcherOutput := make(chan messaging.Folders)
@@ -287,6 +293,8 @@ var (
 
 	quarterSecond = time.Millisecond * 250
 	workDir       string
+
+	gbProject bool
 )
 
 const (


### PR DESCRIPTION
The PR allows user to specify `--gb` to natively support https://github.com/constabulary/gb based projects. The GOPATH is modified to reflect GB environment. 

`findProjectroot` is actually borrowed from GB-itself, as the same logic is performed there to locate the root from given working directory (or it's parents).