### PR TITLE
Support for Passing Global Build Tags

### DIFF
--- a/goconvey.go
+++ b/goconvey.go
@@ -38,6 +38,7 @@ func flags() {
 	flag.DurationVar(&nap, "poll", quarterSecond, "The interval to wait between polling the file system for changes.")
 	flag.IntVar(&packages, "packages", 10, "The number of packages to test in parallel. Higher == faster but more costly in terms of computing.")
 	flag.StringVar(&gobin, "gobin", "go", "The path to the 'go' binary (default: search on the PATH).")
+	flag.StringVar(&gotags, "tags", "", "Build tags to pass to the 'go' binary.")
 	flag.BoolVar(&cover, "cover", true, "Enable package-level coverage statistics. Requires Go 1.2+ and the go cover tool.")
 	flag.IntVar(&depth, "depth", -1, "The directory scanning depth. If -1, scan infinitely deep directory structures. 0: scan working directory. 1+: Scan into nested directories, limited to value.")
 	flag.StringVar(&timeout, "timeout", "0", "The test execution timeout if none is specified in the *.goconvey file (default is '0', which is the same as not providing this option).")
@@ -61,8 +62,9 @@ func main() {
 	log.Printf(initialConfiguration, host, port, nap, cover)
 
 	working := getWorkDir()
+	tags := parseTags()
 	cover = coverageEnabled(cover, reports)
-	shell := system.NewShell(gobin, reports, cover, timeout)
+	shell := system.NewShell(gobin, tags, reports, cover, timeout)
 
 	watcherInput := make(chan messaging.WatcherCommand)
 	watcherOutput := make(chan messaging.Folders)
@@ -269,10 +271,19 @@ func getWorkDir() string {
 	return working
 }
 
+func parseTags() []string {
+	gotags = strings.TrimSpace(gotags)
+	if len(gotags) == 0 {
+		return make([]string, 0, 0)
+	}
+	return strings.Split(gotags, ",")
+}
+
 var (
 	port              int
 	host              string
 	gobin             string
+	gotags            string
 	nap               time.Duration
 	packages          int
 	cover             bool

--- a/web/server/system/shell.go
+++ b/web/server/system/shell.go
@@ -35,7 +35,7 @@ func (self *Shell) GoTest(directory, packageName string, tags, arguments []strin
 	reportPath := filepath.Join(self.reportsPath, reportFilename)
 	reportData := reportPath + ".txt"
 	reportHTML := reportPath + ".html"
-	tagsArg := "-tags=" + strings.Join(append(self.gotags, tags...), ",")
+	tagsArg := "-tags=" + strings.Join(append(self.gotags, tags...), " ")
 
 	goconvey := findGoConvey(directory, self.gobin, packageName, tagsArg).Execute()
 	compilation := compile(directory, self.gobin, tagsArg).Execute()

--- a/web/server/system/shell.go
+++ b/web/server/system/shell.go
@@ -15,14 +15,16 @@ import (
 type Shell struct {
 	coverage       bool
 	gobin          string
+	gotags         []string
 	reportsPath    string
 	defaultTimeout string
 }
 
-func NewShell(gobin, reportsPath string, coverage bool, defaultTimeout string) *Shell {
+func NewShell(gobin string, gotags []string, reportsPath string, coverage bool, defaultTimeout string) *Shell {
 	return &Shell{
 		coverage:       coverage,
 		gobin:          gobin,
+		gotags:         gotags,
 		reportsPath:    reportsPath,
 		defaultTimeout: defaultTimeout,
 	}
@@ -33,7 +35,7 @@ func (self *Shell) GoTest(directory, packageName string, tags, arguments []strin
 	reportPath := filepath.Join(self.reportsPath, reportFilename)
 	reportData := reportPath + ".txt"
 	reportHTML := reportPath + ".html"
-	tagsArg := "-tags=" + strings.Join(tags, ",")
+	tagsArg := "-tags=" + strings.Join(append(self.gotags, tags...), ",")
 
 	goconvey := findGoConvey(directory, self.gobin, packageName, tagsArg).Execute()
 	compilation := compile(directory, self.gobin, tagsArg).Execute()

--- a/web/server/system/shell_integration_test.go
+++ b/web/server/system/shell_integration_test.go
@@ -21,7 +21,7 @@ func TestShellIntegration(t *testing.T) {
 	directory := filepath.Join(filepath.Dir(filename), "..", "watch", "integration_testing", "sub")
 	packageName := "github.com/smartystreets/goconvey/web/server/watch/integration_testing/sub"
 
-	shell := NewShell("go", "", true, "5s")
+	shell := NewShell("go", []string{}, "", true, "5s")
 	output, err := shell.GoTest(directory, packageName, []string{}, []string{"-short"})
 
 	if !strings.Contains(output, "PASS\n") || !strings.Contains(output, "ok") {


### PR DESCRIPTION
This adds support for the command line argument `-tags` that will parse a comma-separated list of build tags that will be passed to the `go` binary on every call.

Given that the `shell.GoTest()` method already had an argument present for tags, and that passing duplicate tags to the `go` binary doesn't have any dire consequences, the tags provided as arguments to `shell.GoTest()` and the tags defined on the command line are merged into one slice.

Should this PR be merged, the _Web UI_ wiki page will need to be updated [here](https://github.com/smartystreets/goconvey/wiki/Web-UI#server-command-line-flags) to list the new `-tags` argument, probably something along the lines of:

```
- tags="": A comma-separated list of build tags to pass to the `go` binary.
```

Resolves #450 