### PR TITLE
Add XTestImports to go list arguments

### DIFF
--- a/web/server/system/shell.go
+++ b/web/server/system/shell.go
@@ -49,7 +49,7 @@ func (self *Shell) GoTest(directory, packageName string, tags, arguments []strin
 ///////////////////////////////////////////////////////////////////////////////
 
 func findGoConvey(directory, gobin, packageName, tagsArg string) Command {
-	return NewCommand(directory, gobin, "list", "-f", "'{{.TestImports}}'", tagsArg, packageName)
+	return NewCommand(directory, gobin, "list", "-f", "'{{.TestImports}}{{.XTestImports}}'", tagsArg, packageName)
 }
 
 func compile(directory, gobin, tagsArg string) Command {


### PR DESCRIPTION
This should fix bug with only one test file that is in an external test package (e.g. `package_test`) or a possible situation whether there are multiple test files in mixed packages, but unique imports from external test package don't get fetched leading to empty list.