### PR TITLE
Add .XTestImports to list of imports searched for GoConvey DSL import

### DIFF
--- a/web/server/system/shell.go
+++ b/web/server/system/shell.go
@@ -49,7 +49,7 @@ func (self *Shell) GoTest(directory, packageName string, tags, arguments []strin
 ///////////////////////////////////////////////////////////////////////////////
 
 func findGoConvey(directory, gobin, packageName, tagsArg string) Command {
-	return NewCommand(directory, gobin, "list", "-f", "'{{.TestImports}}'", tagsArg, packageName)
+	return NewCommand(directory, gobin, "list", "-f", "'{{.XTestImports}} {{.TestImports}}'", tagsArg, packageName)
 }
 
 func compile(directory, gobin, tagsArg string) Command {

--- a/web/server/system/shell_test.go
+++ b/web/server/system/shell_test.go
@@ -11,8 +11,8 @@ func TestShellCommandComposition(t *testing.T) {
 	var (
 		buildFailed      = Command{Error: errors.New("BUILD FAILURE!")}
 		buildSucceeded   = Command{Output: "ok"}
-		goConvey         = Command{Output: "[fmt github.com/smartystreets/goconvey/convey net/http net/http/httptest path runtime strconv strings testing time]"}
-		noGoConvey       = Command{Output: "[fmt net/http net/http/httptest path runtime strconv strings testing time]"}
+		goConvey         = Command{Output: "[] [fmt github.com/smartystreets/goconvey/convey net/http net/http/httptest path runtime strconv strings testing time]"}
+		noGoConvey       = Command{Output: "[] [fmt net/http net/http/httptest path runtime strconv strings testing time]"}
 		errorGoConvey    = Command{Output: "This is a wacky error", Error: errors.New("This happens when running goconvey outside your $GOPATH (symlinked code).")}
 		noCoveragePassed = Command{Output: "PASS\nok  	github.com/smartystreets/goconvey/examples	0.012s"}
 		coveragePassed   = Command{Output: "PASS\ncoverage: 100.0% of statements\nok  	github.com/smartystreets/goconvey/examples	0.012s"}
@@ -48,7 +48,7 @@ func TestShellCommandComposition(t *testing.T) {
 			})
 		})
 
-		Convey("And the package being tested usees the GoConvey DSL (`convey` package)", func() {
+		Convey("And the package being tested uses the GoConvey DSL (`convey` package)", func() {
 			result := runWithCoverage(buildSucceeded, goConvey, yesCoverage, "reportsPath", "/directory", "go", "5s", "-tags=bob", []string{"-arg1", "-arg2"})
 
 			Convey("The returned command should be well formed (and include the -json flag)", func() {


### PR DESCRIPTION
Fixes #442.

From `go list --help`:
```
TestGoFiles    []string // _test.go files in package
XTestGoFiles   []string // _test.go files outside package
TestImports    []string // imports from TestGoFiles
XTestImports   []string // imports from XTestGoFiles
```

Also updates the tests to match the format returned by the new command, and fixes a typo I spotted while doing that.