### PR TITLE
Added ShouldBeError assertion

### DIFF
--- a/convey/assertions.go
+++ b/convey/assertions.go
@@ -65,4 +65,6 @@ var (
 	ShouldHappenWithin         = assertions.ShouldHappenWithin
 	ShouldNotHappenWithin      = assertions.ShouldNotHappenWithin
 	ShouldBeChronological      = assertions.ShouldBeChronological
+
+	ShouldBeError = assertions.ShouldBeError
 )


### PR DESCRIPTION
This commit along with https://github.com/smartystreets/assertions/pull/16 will add the `ShouldBeError` assertion to Goconvey.