### PR TITLE
Stop compiling and testing packages in testdata

### DIFF
--- a/goconvey.go
+++ b/goconvey.go
@@ -128,10 +128,35 @@ func runTestOnUpdates(queue chan messaging.Folders, executor contract.Executor, 
 func extractPackages(folderList messaging.Folders) []*contract.Package {
 	packageList := []*contract.Package{}
 	for _, folder := range folderList {
+		if isInsideTestdata(folder) {
+			continue
+		}
 		hasImportCycle := testFilesImportTheirOwnPackage(folder.Path)
 		packageList = append(packageList, contract.NewPackage(folder, hasImportCycle))
 	}
 	return packageList
+}
+
+// For packages that operate on Go source code files, such as Go tooling, it is
+// important to have a location that will not be considered part of package
+// source to store those files. The official Go tooling selected the testdata
+// folder for this purpose, so we need to ignore folders inside testdata.
+func isInsideTestdata(folder *messaging.Folder) bool {
+	relativePath, err := filepath.Rel(folder.Root, folder.Path)
+	if err != nil {
+		// There should never be a folder that's not inside the root, but if
+		// there is, we can presumably count it as outside a testdata folder as
+		// well
+		return false
+	}
+
+	for _, directory := range strings.Split(filepath.ToSlash(relativePath), "/") {
+		if directory == "testdata" {
+			return true
+		}
+	}
+
+	return false
 }
 
 func extractRoot(folderList messaging.Folders, packageList []*contract.Package) string {


### PR DESCRIPTION
Go tooling, including `go test` treat the testdata directory as an opaque
directory containing data for tests. Unfortunately, goconvey would treat go
source files inside testdata or its subdirectories as creating a package,
causing divergence in behavior from Go tooling.

This commit causes goconvey to not treat anything inside the testdata
directory or subdirectories as a package without removing them from the watch
list. This creates behavioral parity with Go tooling, but means a change in
testdata will still cause tests to be rerun.