### PR TITLE
Added go 1.9 test strings

### DIFF
--- a/web/server/parser/rules.go
+++ b/web/server/parser/rules.go
@@ -4,12 +4,13 @@ import "strings"
 
 func noGoFiles(line string) bool {
 	return strings.HasPrefix(line, "can't load package: ") &&
-		strings.Contains(line, ": no buildable Go source files in ")
+		(strings.Contains(line, ": no buildable Go source files in ") ||
+			strings.Contains(line, ": no Go files in "))
 }
 func buildFailed(line string) bool {
 	return strings.HasPrefix(line, "# ") ||
 		strings.Contains(line, "cannot find package") ||
-		(strings.HasPrefix(line, "can't load package: ") && !strings.Contains(line, ": no Go source files in ")) ||
+		(strings.HasPrefix(line, "can't load package: ") && !(strings.Contains(line, ": no Go source files in ") || strings.Contains(line, ": no Go files in"))) ||
 		(strings.Contains(line, ": found packages ") && strings.Contains(line, ".go) and ") && strings.Contains(line, ".go) in "))
 }
 func noTestFunctions(line string) bool {


### PR DESCRIPTION
The update to 1.9 changed the output for directories
that have no .go files (for example, test data directories).
Added tests for the changed output lines.
Fixes: #494 