### PR TITLE
don't detect diff headers as test titles

### DIFF
--- a/web/server/parser/rules.go
+++ b/web/server/parser/rules.go
@@ -23,7 +23,7 @@ func isNewTest(line string) bool {
 	return strings.HasPrefix(line, "=== ")
 }
 func isTestResult(line string) bool {
-	return strings.HasPrefix(line, "--- ")
+	return strings.HasPrefix(line, "--- ") && !strings.HasPrefix(line, "--- Expected")
 }
 func isPackageReport(line string) bool {
 	return (strings.HasPrefix(line, "FAIL") ||


### PR DESCRIPTION
this is a bit of a hack, but someone else might run into the same problem i did.
basically i have some tests where the output contains a diff header like "---
Expected\n+++ Actual\n..." and that was confusing goconvey. this works for me!