### PR TITLE
fix panic from testify assert output

### DIFF
--- a/web/server/parser/package_parser_test.go
+++ b/web/server/parser/package_parser_test.go
@@ -138,6 +138,12 @@ func TestParsePackage_Golang17Subtests_ReturnsPackageResult(t *testing.T) {
 	assertEqual(t, expectedGolang17Subtests, *actual)
 }
 
+func TestParsePackage_TestifyAssertDiffLines_ShouldNotPanic(t *testing.T) {
+	actual := &contract.PackageResult{PackageName: expectedTestifyAssertDiffLines.PackageName}
+	ParsePackageResults(actual, inputTestifyAssertDiffLines)
+	assertEqual(t, expectedTestifyAssertDiffLines, *actual)
+}
+
 func assertEqual(t *testing.T, expected, actual interface{}) {
 	a, _ := json.Marshal(expected)
 	b, _ := json.Marshal(actual)
@@ -873,6 +879,56 @@ var expectedGolang17Subtests = contract.PackageResult{
 			Line:     0,
 			Message:  "",
 			Stories:  []reporting.ScopeResult{},
+		},
+	},
+}
+
+const inputTestifyAssertDiffLines = `
+=== RUN   Test
+--- FAIL: Test (0.07 seconds)
+        Error Trace:    foo_test.go:10
+	Error:      	Not equal: 
+	            	expected: map[string]string{"sad":"face"}
+	            	actual: map[string]string{"foo":"bar"}
+	            	
+	            	Diff:
+	            	--- Expected
+	            	+++ Actual
+	            	@@ -1,3 +1,3 @@
+	            	 (map[string]string) (len=1) {
+	            	- (string) (len=3) "sad": (string) (len=4) "face"
+	            	+ (string) (len=3) "foo": (string) (len=3) "bar"
+	            	 }
+FAIL
+exit status 1
+FAIL	github.com/smartystreets/goconvey/webserver/examples	0.07s
+`
+
+var expectedTestifyAssertDiffLines = contract.PackageResult{
+	PackageName: "github.com/smartystreets/goconvey/webserver/examples",
+	Elapsed:     0.07,
+	Outcome:     contract.Failed,
+	TestResults: []contract.TestResult{
+		contract.TestResult{
+			TestName: "Test",
+			Elapsed:  0.07,
+			Passed:   false,
+			File:     "",
+			Line:     0,
+			Message: `Error Trace:    foo_test.go:10
+Error:      	Not equal:
+expected: map[string]string{"sad":"face"}
+actual: map[string]string{"foo":"bar"}
+
+Diff:
+--- Expected
++++ Actual
+@@ -1,3 +1,3 @@
+(map[string]string) (len=1) {
+- (string) (len=3) "sad": (string) (len=4) "face"
++ (string) (len=3) "foo": (string) (len=3) "bar"
+}`,
+			Stories: []reporting.ScopeResult{},
 		},
 	},
 }

--- a/web/server/parser/rules.go
+++ b/web/server/parser/rules.go
@@ -1,6 +1,9 @@
 package parser
 
-import "strings"
+import (
+	"regexp"
+	"strings"
+)
 
 func noGoFiles(line string) bool {
 	return strings.HasPrefix(line, "can't load package: ") &&
@@ -22,8 +25,11 @@ func noTestFiles(line string) bool {
 func isNewTest(line string) bool {
 	return strings.HasPrefix(line, "=== ")
 }
+
+var validTestResult = regexp.MustCompile(`^--- (PASS|FAIL|SKIP): .*$`)
+
 func isTestResult(line string) bool {
-	return strings.HasPrefix(line, "--- ")
+	return validTestResult.MatchString(line)
 }
 func isPackageReport(line string) bool {
 	return (strings.HasPrefix(line, "FAIL") ||

--- a/web/server/parser/util.go
+++ b/web/server/parser/util.go
@@ -2,17 +2,24 @@ package parser
 
 import (
 	"math"
-	"strings"
+	"regexp"
 	"time"
 )
+
+// durationFinder look for durations in brackets at the end of lines for
+// example:
+// --- PASS: Test (0.03 seconds)
+// or
+// --- PASS: Test (0.03s)
+// it should be possible to extend this to allow for other units
+var durationFinder = regexp.MustCompile(`^.*\(([0-9.]+)\s?(s|seconds)\)$`)
 
 // parseTestFunctionDuration parses the duration in seconds as a float64
 // from a line of go test output that looks something like this:
 // --- PASS: TestOldSchool_PassesWithMessage (0.03 seconds)
 func parseTestFunctionDuration(line string) float64 {
-	line = strings.Replace(line, "(", "", 1)
-	fields := strings.Split(line, " ")
-	return parseDurationInSeconds(fields[3]+"s", 2)
+	dur := durationFinder.FindStringSubmatch(line)[1]
+	return parseDurationInSeconds(dur+"s", 2)
 }
 
 func parseDurationInSeconds(raw string, precision int) float64 {


### PR DESCRIPTION
ref #502 

this PR fixes an issue where the parser panics due to some output from the https://github.com/stretchr/testify assert package. Specifically when `assert.Equals` (or similar) produces a diff it contains a line like this `--- Expected` which is wrongly being interpreted by goconvey as a test that either passed or failed.

my test case is currently failing to parse filename and line number, some guidence here as to what the expected behaviour should be would be appreicated.