### PR TITLE
Keep indentation of test output

### DIFF
--- a/web/server/parser/packageParser.go
+++ b/web/server/parser/packageParser.go
@@ -78,7 +78,10 @@ func (self *outputParser) recordFinalOutcome(outcome string) {
 }
 
 func (self *outputParser) processTestOutput() {
-	self.line = strings.TrimSpace(self.line)
+	self.line = applyCarriageReturn(self.line)
+	if s := strings.TrimLeft(self.line, " \t"); strings.HasPrefix(s, "--- ") {
+		self.line = s
+	}
 	if isNewTest(self.line) {
 		self.registerTestFunction()
 

--- a/web/server/parser/util.go
+++ b/web/server/parser/util.go
@@ -47,3 +47,23 @@ func round(x float64, precision int) float64 {
 
 	return rounder / float64(pow)
 }
+
+// applyCarriageReturn process line just like terminals do (CR moves
+// cursor to the start of line and next output overwrites previous one)
+// and return final line without CR.
+func applyCarriageReturn(line string) string {
+	output := []rune(line)[:0]
+	cursor := 0
+	for _, r := range line {
+		if r == '\r' {
+			cursor = 0
+		} else if cursor < len(output) {
+			output[cursor] = r
+			cursor++
+		} else {
+			output = append(output, r)
+			cursor++
+		}
+	}
+	return string(output)
+}


### PR DESCRIPTION
Partially this issue was introduced in de953c3, partially it's because of missing `\r` processing (often used to rewrite default output of `testing` package).

Example `go test` output:
```
--- FAIL: TestTestify (0.00s)
	Error Trace:	ws_test.go:13
	Error:      	Not equal: 
	            	expected: 1
	            	actual:   -1
    --- FAIL: TestTestify/Sub_2x (0.00s)
	Error Trace:	ws_test.go:16
    	Error:      	Should not be: 22
	Error Trace:	ws_test.go:17
    	Error:      	Not equal: 
    	            	expected: 22
    	            	actual:   -22
```
is incorrectly shown in goconvey web UI:
```
TestTestify
assertions.go:239: 
                          
	Error Trace:	ws_test.go:13
Error:      	Not equal:
expected: 1
actual:   -1

TestTestify/Sub_2x
assertions.go:239: 
                          
	Error Trace:	ws_test.go:16
Error:      	Should not be: 22
assertions.go:239: 
                          
	Error Trace:	ws_test.go:17
Error:      	Not equal:
expected: 22
actual:   -22
```
This PR fixes it to looks this way:
```
TestTestify
Error Trace:	ws_test.go:13
Error:      	Not equal: 
            	expected: 1
            	actual:   -1

TestTestify/Sub_2x
Error Trace:	ws_test.go:16
Error:      	Should not be: 22
Error Trace:	ws_test.go:17
Error:      	Not equal: 
            	expected: 22
            	actual:   -22
```
This PR adds a bit clever helper function to correctly apply `\r`. If you don't like it then there is alternative dirty way (but I'm unsure is it will work correctly on Windows/Mac):
```go
if i := strings.LastIndex(self.line, "\r"); i >= 0 {
	self.line = self.line[i+1:]
}
```