### PR TITLE
Fix crash on diff

### DIFF
--- a/web/server/parser/packageParser.go
+++ b/web/server/parser/packageParser.go
@@ -79,7 +79,9 @@ func (self *outputParser) recordFinalOutcome(outcome string) {
 
 func (self *outputParser) processTestOutput() {
 	self.line = applyCarriageReturn(self.line)
-	if s := strings.TrimLeft(self.line, " \t"); strings.HasPrefix(s, "--- ") {
+	if s := strings.TrimLeft(self.line, " \t"); strings.HasPrefix(s, "--- SKIP: ") ||
+		strings.HasPrefix(s, "--- FAIL: ") ||
+		strings.HasPrefix(s, "--- PASS: ") {
 		self.line = s
 	}
 	if isNewTest(self.line) {

--- a/web/server/parser/packageParser.go
+++ b/web/server/parser/packageParser.go
@@ -78,7 +78,10 @@ func (self *outputParser) recordFinalOutcome(outcome string) {
 }
 
 func (self *outputParser) processTestOutput() {
-	self.line = strings.TrimSpace(self.line)
+	self.line = applyCarriageReturn(self.line)
+	if s := strings.TrimLeft(self.line, " \t"); strings.HasPrefix(s, "--- ") {
+		self.line = s
+	}
 	if isNewTest(self.line) {
 		self.registerTestFunction()
 

--- a/web/server/parser/util.go
+++ b/web/server/parser/util.go
@@ -47,3 +47,23 @@ func round(x float64, precision int) float64 {
 
 	return rounder / float64(pow)
 }
+
+// applyCarriageReturn process line just like terminals do (CR moves
+// cursor to the start of line and next output overwrites previous one)
+// and return final line without CR.
+func applyCarriageReturn(line string) string {
+	output := []rune(line)[:0]
+	cursor := 0
+	for _, r := range line {
+		if r == '\r' {
+			cursor = 0
+		} else if cursor < len(output) {
+			output[cursor] = r
+			cursor++
+		} else {
+			output = append(output, r)
+			cursor++
+		}
+	}
+	return string(output)
+}


### PR DESCRIPTION
This PR is based on #511 branch.

Testify's output from `assert.Equal(t, []byte(nil), []byte{})`:
```
--- FAIL: TestTestify (0.00s)
    --- FAIL: TestTestify/Equality (0.00s)
	Error Trace:	ws_test.go:13
    	Error:      	Not equal: 
    	            	expected: []byte(nil)
    	            	actual:   []byte{}
    	            	
    	            	Diff:
    	            	--- Expected
    	            	+++ Actual
    	            	@@ -1,2 +1,3 @@
    	            	-([]uint8) <nil>
    	            	+([]uint8) {
    	            	+}
```
crashes goconvey with:
```
panic: runtime error: index out of range

goroutine 18 [running]:
github.com/smartystreets/goconvey/web/server/parser.(*outputParser).recordTestMetadata(0xc4203be8c0)
	/home/powerman/gocode/src/github.com/smartystreets/goconvey/web/server/parser/packageParser.go:109 +0x1b0
github.com/smartystreets/goconvey/web/server/parser.(*outputParser).processTestOutput(0xc4203be8c0)
	/home/powerman/gocode/src/github.com/smartystreets/goconvey/web/server/parser/packageParser.go:91 +0x10d
github.com/smartystreets/goconvey/web/server/parser.(*outputParser).separateTestFunctionsAndMetadata(0xc4203be8c0)
	/home/powerman/gocode/src/github.com/smartystreets/goconvey/web/server/parser/packageParser.go:53 +0x45
github.com/smartystreets/goconvey/web/server/parser.(*outputParser).parse(0xc4203be8c0)
	/home/powerman/gocode/src/github.com/smartystreets/goconvey/web/server/parser/packageParser.go:44 +0x2b
github.com/smartystreets/goconvey/web/server/parser.ParsePackageResults(0xc42006f740, 0xc4200ac400, 0x3b5)
	/home/powerman/gocode/src/github.com/smartystreets/goconvey/web/server/parser/packageParser.go:18 +0x4d
github.com/smartystreets/goconvey/web/server/parser.(*Parser).Parse(0xc420130000, 0xc420170300, 0x11, 0x20)
	/home/powerman/gocode/src/github.com/smartystreets/goconvey/web/server/parser/parser.go:16 +0x29f
github.com/smartystreets/goconvey/web/server/executor.(*Executor).parse(0xc42011c100, 0xc420170300, 0x11, 0x20, 0xffffffffffffffff)
	/home/powerman/gocode/src/github.com/smartystreets/goconvey/web/server/executor/executor.go:47 +0xc8
github.com/smartystreets/goconvey/web/server/executor.(*Executor).ExecuteTests(0xc42011c100, 0xc420170300, 0x11, 0x20, 0x0)
	/home/powerman/gocode/src/github.com/smartystreets/goconvey/web/server/executor/executor.go:36 +0xa8
main.runTestOnUpdates(0xc42012a060, 0x998e00, 0xc42011c100, 0x99c0c0, 0xc42011c140)
	/home/powerman/gocode/src/github.com/smartystreets/goconvey/goconvey.go:120 +0x15d
created by main.main
	/home/powerman/gocode/src/github.com/smartystreets/goconvey/goconvey.go:80 +0x616
```