### PR TITLE
Parse 1.10 and ignore rc/beta/alpha bits

### DIFF
--- a/convey/reporting/reporter_test.go
+++ b/convey/reporting/reporter_test.go
@@ -56,7 +56,7 @@ func assertEqual(t *testing.T, expected, actual int) {
 func assertNil(t *testing.T, err error) {
 	if err != nil {
 		_, _, line, _ := runtime.Caller(1)
-		t.Errorf("Error should have been <nil> (but wasn't). See line %d", err, line)
+		t.Errorf("Error should have been <nil> (but was %q). See line %d", err, line)
 	}
 }
 

--- a/goconvey.go
+++ b/goconvey.go
@@ -222,7 +222,7 @@ func versionOnePointTwoOrGreater() bool {
 		return false
 	}
 
-	var minorStr string
+	var minorStr = majorminor[1]
 	for i, r := range majorminor[1] {
 		if !unicode.IsDigit(r) {
 			minorStr = majorminor[1][:i]
@@ -231,7 +231,7 @@ func versionOnePointTwoOrGreater() bool {
 	}
 	minor, err := strconv.Atoi(minorStr)
 	if err != nil {
-		log.Printf(unableToDetermineGoVersion, s)
+		log.Printf(unableToDetermineGoVersion, s, err)
 		return false
 	}
 
@@ -324,7 +324,7 @@ var (
 const (
 	initialConfiguration       = "Initial configuration: [host: %s] [port: %d] [poll: %v] [cover: %v]\n"
 	pleaseUpgradeGoVersion     = "Go version is less that 1.2 (%s), please upgrade to the latest stable version to enable coverage reporting.\n"
-	unableToDetermineGoVersion = "Go version could not be determined. Possibly not a tagged version? %q\n"
+	unableToDetermineGoVersion = "Go version could not be determined. %q possibly not a tagged version? err: %s\n"
 	coverToolMissing           = "Go cover tool is not installed or not accessible: for Go < 1.5 run`go get golang.org/x/tools/cmd/cover`\n For >= Go 1.5 run `go install $GOROOT/src/cmd/cover`\n"
 	reportDirectoryUnavailable = "Could not find or create the coverage report directory (at: '%s'). You probably won't see any coverage statistics...\n"
 )


### PR DESCRIPTION
Just a quick fix for parsing 1.10 as higher than 1.2. assertNil incorrect arg count. I'm not sure the latter is the correct fix, but seems Ok enough. 