### PR TITLE
Add stack trace for failed test

### DIFF
--- a/convey/reporting/init.go
+++ b/convey/reporting/init.go
@@ -56,7 +56,7 @@ var (
 	dotError        = "E"
 	dotSkip         = "S"
 	errorTemplate   = "* %s \nLine %d: - %v \n%s\n"
-	failureTemplate = "* %s \nLine %d:\n%s\n"
+	failureTemplate = "* %s \nLine %d:\n%s\n%s\n"
 )
 
 var (

--- a/convey/reporting/problems.go
+++ b/convey/reporting/problems.go
@@ -53,7 +53,7 @@ func (self *problem) showFailures() {
 			self.out.Println("\nFailures:\n")
 			self.out.Indent()
 		}
-		self.out.Println(failureTemplate, f.File, f.Line, f.Failure)
+		self.out.Println(failureTemplate, f.File, f.Line, f.Failure, f.StackTrace)
 	}
 }
 


### PR DESCRIPTION
Sometimes I want to reuse some parts of the test code and this might lead to multiple nested levels of functions. In this case tracing the line where the test is failed is time consuming without the stack trace. So I adding stack trace to make this process faster.