### PR TITLE
Open web browser on windows

### DIFF
--- a/goconvey.go
+++ b/goconvey.go
@@ -89,9 +89,9 @@ func main() {
 
 func browserCmd() (string, bool) {
 	browser := map[string]string{
-		"darwin": "open",
-		"linux":  "xdg-open",
-		"win32":  "start",
+		"darwin":  "open",
+		"linux":   "xdg-open",
+		"windows": "start",
 	}
 	cmd, ok := browser[runtime.GOOS]
 	return cmd, ok


### PR DESCRIPTION
Fixes launching web browser when `GOOS` is `windows` (which is the `GOOS` used on Windows, rather than `win32`). As seen here:

```text
...
2018/07/25 19:59:09 goconvey.go:194: Serving HTTP at: http://127.0.0.1:8080
2018/07/25 19:59:09 goconvey.go:103: Skipped launching browser for this OS: windows
...
```