### PR TITLE
Introducing go mod (or "go modules", or "vgo")

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,7 @@
+module github.com/smartystreets/goconvey
+
+require (
+	github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 // indirect
+	github.com/jtolds/gls v4.2.1+incompatible
+	github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,6 @@
+github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 h1:EGx4pi6eqNxGaHF6qqu48+N2wcFQ5qg5FXgOdqsJ5d8=
+github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
+github.com/jtolds/gls v4.2.1+incompatible h1:fSuqC+Gmlu6l/ZYAoZzx2pyucC8Xza35fpRVWLVmUEE=
+github.com/jtolds/gls v4.2.1+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
+github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d h1:zE9ykElWQ6/NYmHa3jpm/yHnI4xSofP+UP6SpjHcSeM=
+github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=


### PR DESCRIPTION
That would be nice to add Go modules support to this repo, so for those who already started dealing with `go mod` it'll be a little bit simpler to deal with goconvey.

I didn't make any manual fixes here. I simply called two commands to prepare this PR:
- `GO111MODULE=on go mod init` to create a general go,mod file
- `GO111MODULE=on go mod tidy` to get the list of dependencies of the project

Thanks!