### PR TITLE
handle error message when no go files exists for go 1.11

### DIFF
--- a/web/server/parser/rules.go
+++ b/web/server/parser/rules.go
@@ -4,8 +4,9 @@ import "strings"
 
 func noGoFiles(line string) bool {
 	return strings.HasPrefix(line, "can't load package: ") &&
-		(strings.Contains(line, ": no buildable Go source files in ") || strings.Contains(line, ": no Go "))
-
+		(strings.Contains(line, ": no buildable Go source files in ") ||
+			strings.Contains(line, ": no Go ") ||
+			strings.Contains(line, "cannot find module providing package"))
 }
 func buildFailed(line string) bool {
 	return strings.HasPrefix(line, "# ") ||


### PR DESCRIPTION
go 1.11 has changed the error message. 
the message looks like this 
```
can't load package: package github.com/0nedark/serv/src: unknown import path "github.com/0nedark/serv/src": cannot find module providing package github.com/0nedark/serv/src
```
This PR fixes this problem.