### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/convey/doc.go
+++ b/convey/doc.go
@@ -202,7 +202,7 @@ func SuppressConsoleStatistics() {
 	reporting.SuppressConsoleStatistics()
 }
 
-// ConsoleStatistics may be called at any time to print assertion statistics.
+// PrintConsoleStatistics may be called at any time to print assertion statistics.
 // Generally, the best place to do this would be in a TestMain function,
 // after all tests have been run. Something like this:
 //

--- a/convey/reporting/init.go
+++ b/convey/reporting/init.go
@@ -71,7 +71,7 @@ var consoleStatistics = NewStatisticsReporter(NewPrinter(NewConsole()))
 func SuppressConsoleStatistics() { consoleStatistics.Suppress() }
 func PrintConsoleStatistics()    { consoleStatistics.PrintSummary() }
 
-// QuiteMode disables all console output symbols. This is only meant to be used
+// QuietMode disables all console output symbols. This is only meant to be used
 // for tests that are internal to goconvey where the output is distracting or
 // otherwise not needed in the test output.
 func QuietMode() {


### PR DESCRIPTION
Hi, we updated some exported function comments based on best practices from Effective Go. It’s admittedly a relatively minor fix up. Does this help you?