### PR TITLE
Correctly identify package names in modules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,4 +4,5 @@ require (
 	github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 // indirect
 	github.com/jtolds/gls v4.20.0+incompatible
 	github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d
+	golang.org/x/tools v0.0.0-20190328211700-ab21143f2384
 )

--- a/go.sum
+++ b/go.sum
@@ -4,3 +4,9 @@ github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d h1:zE9ykElWQ6/NYmHa3jpm/yHnI4xSofP+UP6SpjHcSeM=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/tools v0.0.0-20190328211700-ab21143f2384 h1:TFlARGu6Czu1z7q93HTxcP1P+/ZFC/IKythI5RzrnRg=
+golang.org/x/tools v0.0.0-20190328211700-ab21143f2384/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=

--- a/goconvey_1_8.go
+++ b/goconvey_1_8.go
@@ -1,0 +1,42 @@
+// +build !go1.9
+
+// To work correctly with out of GOPATH modules, some functions needed to
+// switch from using go/build to golang.org/x/tools/go/packages. But that
+// package depends on changes to go/types that were introduced in Go 1.9. Since
+// modules weren't introduced until Go 1.11, users of Go 1.8 or below can't be
+// using modules, so they can continue to use go/build.
+
+package main
+
+import (
+	"go/build"
+	"strings"
+)
+
+// This method exists because of a bug in the go cover tool that
+// causes an infinite loop when you try to run `go test -cover`
+// on a package that has an import cycle defined in one of it's
+// test files. Yuck.
+func testFilesImportTheirOwnPackage(packagePath string) bool {
+	meta, err := build.ImportDir(packagePath, build.AllowBinary)
+	if err != nil {
+		return false
+	}
+
+	for _, dependency := range meta.TestImports {
+		if dependency == meta.ImportPath {
+			return true
+		}
+	}
+	return false
+}
+
+func resolvePackageName(path string) string {
+	pkg, err := build.ImportDir(path, build.FindOnly)
+	if err == nil {
+		return pkg.ImportPath
+	}
+
+	nameArr := strings.Split(path, endGoPath)
+	return nameArr[len(nameArr)-1]
+}

--- a/goconvey_1_9.go
+++ b/goconvey_1_9.go
@@ -1,0 +1,64 @@
+// +build go1.9
+
+// To work correctly with out of GOPATH modules, some functions needed to
+// switch from using go/build to golang.org/x/tools/go/packages. But that
+// package depends on changes to go/types that were introduced in Go 1.9. Since
+// modules weren't introduced until Go 1.11, using
+// golang.org/x/tools/go/packages can safely be restricted to users of Go 1.9
+// or above.
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"golang.org/x/tools/go/packages"
+)
+
+// This method exists because of a bug in the go cover tool that
+// causes an infinite loop when you try to run `go test -cover`
+// on a package that has an import cycle defined in one of it's
+// test files. Yuck.
+func testFilesImportTheirOwnPackage(packagePath string) bool {
+	meta, err := packages.Load(
+		&packages.Config{
+			Mode:  packages.NeedName | packages.NeedImports,
+			Tests: true,
+		},
+		packagePath,
+	)
+	if err != nil {
+		return false
+	}
+
+	testPackageID := fmt.Sprintf("%s [%s.test]", meta[0], meta[0])
+
+	for _, testPackage := range meta[1:] {
+		if testPackage.ID != testPackageID {
+			continue
+		}
+
+		for dependency := range testPackage.Imports {
+			if dependency == meta[0].PkgPath {
+				return true
+			}
+		}
+		break
+	}
+	return false
+}
+
+func resolvePackageName(path string) string {
+	pkg, err := packages.Load(
+		&packages.Config{
+			Mode: packages.NeedName,
+		},
+		path,
+	)
+	if err == nil {
+		return pkg[0].PkgPath
+	}
+
+	nameArr := strings.Split(path, endGoPath)
+	return nameArr[len(nameArr)-1]
+}

--- a/web/server/contract/result.go
+++ b/web/server/contract/result.go
@@ -1,11 +1,6 @@
 package contract
 
 import (
-	"path/filepath"
-	"strings"
-
-	"golang.org/x/tools/go/packages"
-
 	"github.com/smartystreets/goconvey/convey/reporting"
 	"github.com/smartystreets/goconvey/web/server/messaging"
 )
@@ -24,10 +19,10 @@ type Package struct {
 	HasImportCycle bool
 }
 
-func NewPackage(folder *messaging.Folder, hasImportCycle bool) *Package {
+func NewPackage(folder *messaging.Folder, name string, hasImportCycle bool) *Package {
 	self := new(Package)
 	self.Path = folder.Path
-	self.Name = resolvePackageName(self.Path)
+	self.Name = name
 	self.Result = NewPackageResult(self.Name)
 	self.Ignored = folder.Ignored
 	self.Disabled = folder.Disabled
@@ -103,23 +98,3 @@ func NewTestResult(testName string) *TestResult {
 	self.TestName = testName
 	return self
 }
-
-func resolvePackageName(path string) string {
-	pkg, err := packages.Load(
-		&packages.Config{
-			Mode: packages.NeedName,
-		},
-		path,
-	)
-	if err == nil {
-		return pkg[0].PkgPath
-	}
-
-	nameArr := strings.Split(path, endGoPath)
-	return nameArr[len(nameArr)-1]
-}
-
-const (
-	separator = string(filepath.Separator)
-	endGoPath = separator + "src" + separator
-)

--- a/web/server/contract/result.go
+++ b/web/server/contract/result.go
@@ -4,7 +4,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"go/build"
+	"golang.org/x/tools/go/packages"
 
 	"github.com/smartystreets/goconvey/convey/reporting"
 	"github.com/smartystreets/goconvey/web/server/messaging"
@@ -105,9 +105,14 @@ func NewTestResult(testName string) *TestResult {
 }
 
 func resolvePackageName(path string) string {
-	pkg, err := build.ImportDir(path, build.FindOnly)
+	pkg, err := packages.Load(
+		&packages.Config{
+			Mode: packages.NeedName,
+		},
+		path,
+	)
 	if err == nil {
-		return pkg.ImportPath
+		return pkg[0].PkgPath
 	}
 
 	nameArr := strings.Split(path, endGoPath)


### PR DESCRIPTION
Currently, GoConvey uses go/build and `build.ImportDir()` to collect
information about a package, including its name. Under modules that
live outside of the GOPATH, this resolution breaks, and every module
ends up with the name ".". At the very least this breaks coverage by
causing all coverage reports to be written to client/reports.html
instead of client/reports/<opackage specific>.html.

The core issue is the go/build does not fully support modules. There
was a partial fix submitted in https://github.com/golang/go/commit/f85125345cc5d3eb054c90bfca4bda3544d7fcab,
but it only works if the package being looked up is being looked up by
name, not by path, and GoConvey somewhat necessarily uses the path. As
outlined in the above commit, the intended solution is to use the
golang.org/x/tools/go/packages which will hopefully be migrated to
go/packages in a future Go version.