### PR TITLE
Using a temp dir to store client resources to make coverage test work

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/smartystreets/goconvey
 require (
 	github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 // indirect
 	github.com/jtolds/gls v4.20.0+incompatible
+	github.com/otiai10/copy v1.0.2
 	github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d
 	golang.org/x/tools v0.0.0-20190328211700-ab21143f2384
 )

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,11 @@ github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 h1:EGx4pi6eqNxGa
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
+github.com/otiai10/copy v1.0.2 h1:DDNipYy6RkIkjMwy+AWzgKiNTyj2RUI9yEMeETEpVyc=
+github.com/otiai10/copy v1.0.2/go.mod h1:c7RpqBkwMom4bYTSkLSym4VSJz/XtncWRAj/J4PEIMY=
+github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95/go.mod h1:9qAhocn7zKJG+0mI8eUu6xqkFDYS2kb2saOteoSB3cE=
+github.com/otiai10/mint v1.3.0 h1:Ady6MKVezQwHBkGzLFbrsywyp09Ah7rkmfjV3Bcr5uc=
+github.com/otiai10/mint v1.3.0/go.mod h1:F5AjcsTsWUqX+Na9fpHb52P8pcRX2CI6A3ctIT91xUo=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d h1:zE9ykElWQ6/NYmHa3jpm/yHnI4xSofP+UP6SpjHcSeM=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/goconvey.go
+++ b/goconvey.go
@@ -7,6 +7,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"io/ioutil"
 	"log"
 	"net"
 	"net/http"
@@ -19,6 +20,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/otiai10/copy"
 	"github.com/smartystreets/goconvey/web/server/api"
 	"github.com/smartystreets/goconvey/web/server/contract"
 	"github.com/smartystreets/goconvey/web/server/executor"
@@ -52,6 +54,20 @@ func flags() {
 func folders() {
 	_, file, _, _ := runtime.Caller(0)
 	here := filepath.Dir(file)
+	origin := filepath.Join(here, "/web/client")
+
+	var err error
+	tmpStatic, err = ioutil.TempDir("", "goconvey")
+	if err == nil {
+		static = filepath.Join(tmpStatic, "/web/client")
+		if err = copy.Copy(origin, static); err != nil {
+			log.Println(err)
+			os.Exit(1)
+		}
+	} else {
+		static = origin
+	}
+
 	static = filepath.Join(here, "/web/client")
 	reports = filepath.Join(static, "reports")
 }
@@ -281,6 +297,7 @@ var (
 
 	quarterSecond = time.Millisecond * 250
 	workDir       string
+	tmpStatic     string
 )
 
 const (


### PR DESCRIPTION
I had the same problem with #564 , after a simple code review, I figured out that using a temp dir to store the resources may be a solution.

Here is my quick and dirty fix. But here're few things should be noticed:

1. Another dependency was added to copy assets directory;
2. Code for clean temp dir was not implemented yet;

Tested in OSX/Ubuntu platform.