### PR TITLE
Define a new compile func for go 1.16

### DIFF
--- a/web/server/system/shell.go
+++ b/web/server/system/shell.go
@@ -52,10 +52,6 @@ func findGoConvey(directory, gobin, packageName, tagsArg string) Command {
 	return NewCommand(directory, gobin, "list", "-f", "'{{.TestImports}}{{.XTestImports}}'", tagsArg, packageName)
 }
 
-func compile(directory, gobin, tagsArg string) Command {
-	return NewCommand(directory, gobin, "test", "-i", tagsArg)
-}
-
 func runWithCoverage(compile, goconvey Command, coverage bool, reportPath, directory, gobin, defaultTimeout, tagsArg string, customArguments []string) Command {
 	if compile.Error != nil || goconvey.Error != nil {
 		return compile

--- a/web/server/system/shell_1_16.go
+++ b/web/server/system/shell_1_16.go
@@ -1,0 +1,7 @@
+// +build go1.16
+
+package system
+
+func compile(directory, gobin, tagsArg string) Command {
+	return NewCommand(directory, gobin, "test", tagsArg)
+}

--- a/web/server/system/shell_older_than_1_16.go
+++ b/web/server/system/shell_older_than_1_16.go
@@ -1,0 +1,7 @@
+// +build !go1.16
+
+package system
+
+func compile(directory, gobin, tagsArg string) Command {
+	return NewCommand(directory, gobin, "test", "-i", tagsArg)
+}


### PR DESCRIPTION
`go test -i` is deprecated in go 1.16, and it makes the output parsing
fail, leading to to no coverage reported.

closes https://github.com/smartystreets/goconvey/issues/613