### PR TITLE
add additional 'runTestArgs' for go test command

### DIFF
--- a/goconvey.go
+++ b/goconvey.go
@@ -45,6 +45,7 @@ func flags() {
 	flag.StringVar(&excludedDirs, "excludedDirs", "vendor,node_modules", "A comma separated list of directories that will be excluded from being watched.")
 	flag.StringVar(&workDir, "workDir", "", "set goconvey working directory (default current directory).")
 	flag.BoolVar(&autoLaunchBrowser, "launchBrowser", true, "toggle auto launching of browser.")
+	flag.StringVar(&runTestArgs, "runTestArgs", "", "additional arguments for exec 'go test' command.")
 
 	log.SetOutput(os.Stdout)
 	log.SetFlags(log.LstdFlags | log.Lshortfile)
@@ -62,7 +63,7 @@ func main() {
 
 	working := getWorkDir()
 	cover = coverageEnabled(cover, reports)
-	shell := system.NewShell(gobin, reports, cover, timeout)
+	shell := system.NewShell(gobin, reports, cover, timeout, runTestArgs)
 
 	watcherInput := make(chan messaging.WatcherCommand)
 	watcherOutput := make(chan messaging.Folders)
@@ -300,6 +301,7 @@ var (
 	watchedSuffixes   string
 	excludedDirs      string
 	autoLaunchBrowser bool
+	runTestArgs       string
 
 	static  string
 	reports string

--- a/web/server/system/shell.go
+++ b/web/server/system/shell.go
@@ -17,14 +17,16 @@ type Shell struct {
 	gobin          string
 	reportsPath    string
 	defaultTimeout string
+	runTestArgs    string
 }
 
-func NewShell(gobin, reportsPath string, coverage bool, defaultTimeout string) *Shell {
+func NewShell(gobin, reportsPath string, coverage bool, defaultTimeout string, runTestArgs string) *Shell {
 	return &Shell{
 		coverage:       coverage,
 		gobin:          gobin,
 		reportsPath:    reportsPath,
 		defaultTimeout: defaultTimeout,
+		runTestArgs:    runTestArgs,
 	}
 }
 
@@ -34,6 +36,11 @@ func (self *Shell) GoTest(directory, packageName string, tags, arguments []strin
 	reportData := reportPath + ".txt"
 	reportHTML := reportPath + ".html"
 	tagsArg := "-tags=" + strings.Join(tags, ",")
+
+	// add additional go test arguments
+	if self.runTestArgs != "" {
+		tagsArg = tagsArg + " " + self.runTestArgs
+	}
 
 	goconvey := findGoConvey(directory, self.gobin, packageName, tagsArg).Execute()
 	compilation := compile(directory, self.gobin, tagsArg).Execute()

--- a/web/server/system/shell.go
+++ b/web/server/system/shell.go
@@ -39,7 +39,12 @@ func (self *Shell) GoTest(directory, packageName string, tags, arguments []strin
 
 	// add additional go test arguments
 	if self.runTestArgs != "" {
-		tagsArg = tagsArg + " " + self.runTestArgs
+		if arguments == nil {
+			arguments = make([]string, 1)
+			arguments[0] = self.runTestArgs
+		} else {
+			arguments = append(arguments, self.runTestArgs)
+		}
 	}
 
 	goconvey := findGoConvey(directory, self.gobin, packageName, tagsArg).Execute()

--- a/web/server/system/shell_integration_test.go
+++ b/web/server/system/shell_integration_test.go
@@ -21,7 +21,7 @@ func TestShellIntegration(t *testing.T) {
 	directory := filepath.Join(filepath.Dir(filename), "..", "watch", "integration_testing", "sub")
 	packageName := "github.com/smartystreets/goconvey/web/server/watch/integration_testing/sub"
 
-	shell := NewShell("go", "", true, "5s")
+	shell := NewShell("go", "", true, "5s", "")
 	output, err := shell.GoTest(directory, packageName, []string{}, []string{"-short"})
 
 	if !strings.Contains(output, "PASS\n") || !strings.Contains(output, "ok") {


### PR DESCRIPTION
in some case that need add additional arguements for go test. eg. gomonkey project need run mock test case by add -gcflags="all=-N -l" arguments.
here is the example to show how to run goconvey with this argument:
goconvey -runTestArgs="-gcflags=all=-N -l"