### PR TITLE
Fix #639: Disable pre-compilation for Go 1.16+

### DIFF
--- a/web/server/system/shell_1_16.go
+++ b/web/server/system/shell_1_16.go
@@ -3,5 +3,8 @@
 package system
 
 func compile(directory, gobin, tagsArg string) Command {
-	return NewCommand(directory, gobin, "test", tagsArg)
+	// Don't pre-compile on 1.16
+	// TODO(iannucci): rework the whole compilation feature to compile all
+	// test binaries up front in a single `go` command.
+	return Command{}
 }


### PR DESCRIPTION
The Go compiler cache already mitigates the main benefit of the
previous `go test -i` invocations. The previous replacement (running
`go test`) makes goconvey slower and also breaks the UI :).

At some point (I think) this should all be restructured so that we
can pre-build all test binaries with a single `go test -c`
invocation (so that we can take advantage of Go's internal
compile scheduling). For now we'll just skip the pre-compilation
step in order to un-break goconvey.