### PR TITLE
Refine third-party lib checking scripts.

### DIFF
--- a/check_third_party.sh
+++ b/check_third_party.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 
-./web/client/resources/js/lib/update.sh
+cd "$(dirname $(realpath $0))"
 
-if ! (git diff-files --quiet); then
+sh ./web/client/resources/js/lib/update.sh
+
+if ! (git diff-files --quiet web/client/resources/js/lib); then
   echo "Third party libraries don't match their .url files."
   echo "Re-run ./web/client/resources/js/lib/update.sh"
   exit 1

--- a/web/client/resources/js/lib/update.sh
+++ b/web/client/resources/js/lib/update.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+cd "$(dirname $(realpath $0))"
+
 config_file=()
 
 for url in *.url; do


### PR DESCRIPTION
This allows the scripts to correctly run from any directory, and makes 
the root check script only evaluate changes in the correct subdirectory.