### PR TITLE
Update installation to use 'go install'

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ You can ask questions about how to use GoConvey on [StackOverflow](http://stacko
 Installation
 ------------
 
-	$ go get github.com/smartystreets/goconvey
+	$ go install github.com/smartystreets/goconvey@latest
 
 [Quick start](https://github.com/smartystreets/goconvey/wiki#get-going-in-25-seconds)
 -----------


### PR DESCRIPTION
'go get' is deprecated. Update to use the 'go install foo@latest' syntax.