### PR TITLE
fix document about "go get"

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ You can ask questions about how to use GoConvey on [StackOverflow](http://stacko
 Installation
 ------------
 
-	$ go get github.com/smartystreets/goconvey
+	$ go install github.com/smartystreets/goconvey
 
 [Quick start](https://github.com/smartystreets/goconvey/wiki#get-going-in-25-seconds)
 -----------


### PR DESCRIPTION
detail:
Deprecation of 'go get' for installing executables https://docs.studygolang.com/doc/go-get-install-deprecation