### PR TITLE
Remove references to http://goconvey.co as malware squatters appear to have taken it

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,6 @@ GoConvey is a popular 2-pronged, open-source github project (1,600+ stargazers, 
 
 ----
 
-- http://goconvey.co/
 - https://github.com/smartystreets/goconvey
 - https://github.com/smartystreets/goconvey/wiki
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ GoConvey is awesome Go testing
 [![GoDoc](https://godoc.org/github.com/smartystreets/goconvey?status.svg)](http://godoc.org/github.com/smartystreets/goconvey)
 
 
-Welcome to GoConvey, a yummy Go testing tool for gophers. Works with `go test`. Use it in the terminal or browser according to your viewing pleasure. **[View full feature tour.](http://goconvey.co)**
+Welcome to GoConvey, a yummy Go testing tool for gophers. Works with `go test`. Use it in the terminal or browser according to your viewing pleasure.
 
 GoConvey supports the current versions of Go (see the official Go
 [release policy](https://golang.org/doc/devel/release#policy)). Currently
@@ -118,11 +118,6 @@ Check out the
 - [GoConvey wiki](https://github.com/smartystreets/goconvey/wiki),
 - [![GoDoc](https://godoc.org/github.com/smartystreets/goconvey?status.png)](http://godoc.org/github.com/smartystreets/goconvey)
 - and the *_test.go files scattered throughout this project.
-
-[Screenshots](http://goconvey.co)
------------
-
-For web UI and terminal screenshots, check out [the full feature tour](http://goconvey.co).
 
 Contributors
 ----------------------

--- a/web/client/index.html
+++ b/web/client/index.html
@@ -36,7 +36,7 @@
 			<div id="controls" class="controls hide-narrow">
 				<div class="server-not-down">
 					<ul>
-						<li id="logo" title="Powered by GoConvey"><a href="http://goconvey.co" target="_blank">GoConvey</a></li>
+						<li id="logo" title="Powered by GoConvey"><a href="https://github.com/smartystreets/goconvey" target="_blank">GoConvey</a></li>
 					</ul>
 
 					<div class="float-left" id="path-container">


### PR DESCRIPTION
The first time I clicked it, I was HTTP 302 redirected to a fake malware scanner, but every subsequent time I was redirected to a seeming blank page under the goconvey.co domain.

This change simply removes all refererces to http://goconvey.co