### PR TITLE
fix: fix a few tests that were broken at HEAD

### DIFF
--- a/convey/stack_trace_test.go
+++ b/convey/stack_trace_test.go
@@ -9,14 +9,14 @@ import (
 	"github.com/smartystreets/goconvey/convey/reporting"
 )
 
-var goroutineCounter = regexp.MustCompile(`goroutine \d+ \[`)
+var goroutineRE = regexp.MustCompile(`goroutine \d+ \[`)
 
 // countGoroutines takes a test output file and counts the number of goroutines
 // that were mentioned inside it. This does this by hunting for lines such as
 // "goroutine 42 [running]", while excluding secondary mentions of already-counted
 // goroutines.
 func countGoroutines(testOutput string) int {
-	return len(goroutineCounter.FindAllStringSubmatch(testOutput, -1))
+	return len(goroutineRE.FindAllStringSubmatch(testOutput, -1))
 }
 
 func TestStackTrace(t *testing.T) {

--- a/web/server/parser/packageParser.go
+++ b/web/server/parser/packageParser.go
@@ -144,7 +144,7 @@ var coverageStatementRE = regexp.MustCompile(`coverage: (\d+\.\d)%%? of statemen
 func (self *outputParser) recordCoverageSummary(summary string) {
 	matches := coverageStatementRE.FindStringSubmatch(summary)
 
-	coverage := float64(-1)
+	coverage := -1.0
 	// if there were no matches, or if matches[1] doesn't parse as a float, then we'll return -1
 	if len(matches) != 0 {
 		coverage, _ = strconv.ParseFloat(matches[1], 64)

--- a/web/server/parser/package_parser_test.go
+++ b/web/server/parser/package_parser_test.go
@@ -3,7 +3,7 @@ package parser
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"strings"
 	"testing"
@@ -13,7 +13,7 @@ import (
 )
 
 func init() {
-	log.SetOutput(ioutil.Discard)
+	log.SetOutput(io.Discard)
 }
 
 func TestParsePackage_NoGoFiles_ReturnsPackageResult(t *testing.T) {

--- a/web/server/watch/integration_testing/sub/.gitignore
+++ b/web/server/watch/integration_testing/sub/.gitignore
@@ -1,2 +1,2 @@
-github.com-smartystreets-goconvey-web-server-integration_testing-sub.html
-github.com-smartystreets-goconvey-web-server-integration_testing-sub.txt
+github.com-smartystreets-goconvey-web-server-watch-integration_testing-sub.html
+github.com-smartystreets-goconvey-web-server-watch-integration_testing-sub.txt


### PR DESCRIPTION
one of these tests double-counted goroutines, because logging output now includes "goroutine" twice. This looks for just the first instance.

the other test failed on test instances which used multiple "%" signs after coverage numbers. It works with this change, and IMO it's simpler than it was as well.

also update a gitignore to use a correct new path