### PR TITLE
fix(web): fix nondeterministic tests

### DIFF
--- a/web/server/watch/integration.go
+++ b/web/server/watch/integration.go
@@ -43,91 +43,90 @@ func NewWatcher(rootFolder string, folderDepth int, nap time.Duration,
 	}
 }
 
-func (this *Watcher) Listen() {
+func (w *Watcher) Listen() {
 	for {
-		if this.stopped {
-			return
+		if !w.paused {
+			w.scan()
 		}
-
 		select {
-
-		case command := <-this.input:
-			this.respond(command)
-
-		default:
-			if !this.paused {
-				this.scan()
+		case command := <-w.input:
+			if stopped := w.respond(command); stopped {
+				return
 			}
-			time.Sleep(this.nap)
+		case <-time.After(w.nap):
+			break
 		}
 	}
 }
 
-func (this *Watcher) respond(command messaging.WatcherCommand) {
+// respond handles the command and returns whether the watcher is permanently stopped
+func (w *Watcher) respond(command messaging.WatcherCommand) bool {
 	switch command.Instruction {
 
 	case messaging.WatcherAdjustRoot:
 		log.Println("Adjusting root...")
-		this.rootFolder = command.Details
-		this.execute()
+		w.rootFolder = command.Details
+		w.execute()
 
 	case messaging.WatcherIgnore:
 		log.Println("Ignoring specified folders")
-		this.ignore(command.Details)
+		w.ignore(command.Details)
 		// Prevent a filesystem change due to the number of active folders changing
-		_, checksum := this.gather()
-		this.set(checksum)
+		_, checksum := w.gather()
+		w.set(checksum)
 
 	case messaging.WatcherReinstate:
 		log.Println("Reinstating specified folders")
-		this.reinstate(command.Details)
+		w.reinstate(command.Details)
 		// Prevent a filesystem change due to the number of active folders changing
-		_, checksum := this.gather()
-		this.set(checksum)
+		_, checksum := w.gather()
+		w.set(checksum)
 
 	case messaging.WatcherPause:
 		log.Println("Pausing watcher...")
-		this.paused = true
+		w.paused = true
 
 	case messaging.WatcherResume:
 		log.Println("Resuming watcher...")
-		this.paused = false
+		w.paused = false
 
 	case messaging.WatcherExecute:
 		log.Println("Gathering folders for immediate execution...")
-		this.execute()
+		w.execute()
 
 	case messaging.WatcherStop:
 		log.Println("Stopping the watcher...")
-		close(this.output)
-		this.stopped = true
+		close(w.output)
+		w.stopped = true
+		return true
 
 	default:
 		log.Println("Unrecognized command from server:", command.Instruction)
 	}
+	return false
 }
 
-func (this *Watcher) execute() {
-	folders, _ := this.gather()
-	this.sendToExecutor(folders)
+func (w *Watcher) execute() {
+	folders, _ := w.gather()
+	w.sendToExecutor(folders)
 }
 
-func (this *Watcher) scan() {
-	folders, checksum := this.gather()
+func (w *Watcher) scan() {
+	folders, checksum := w.gather()
 
-	if checksum == this.fileSystemState {
+	if checksum == w.fileSystemState {
 		return
 	}
 
-	log.Println("File system state modified, publishing current folders...", this.fileSystemState, checksum)
+	log.Println("File system state modified, publishing current folders...", w.fileSystemState, checksum)
 
-	defer this.set(checksum)
-	this.sendToExecutor(folders)
+	defer w.set(checksum)
+	w.sendToExecutor(folders)
 }
 
-func (this *Watcher) gather() (folders messaging.Folders, checksum int64) {
-	items := YieldFileSystemItems(this.rootFolder, this.excludedDirs)
-	folderItems, profileItems, goFileItems := Categorize(items, this.rootFolder, this.watchSuffixes)
+func (w *Watcher) gather() (folders messaging.Folders, checksum int64) {
+	items := YieldFileSystemItems(w.rootFolder, w.excludedDirs)
+	folderItems, profileItems, goFileItems := Categorize(items, w.rootFolder, w.watchSuffixes)
 
 	for _, item := range profileItems {
 		// TODO: don't even bother if the item's size is over a few hundred bytes...
@@ -136,9 +135,9 @@ func (this *Watcher) gather() (folders messaging.Folders, checksum int64) {
 	}
 
 	folders = CreateFolders(folderItems)
-	LimitDepth(folders, this.folderDepth)
+	LimitDepth(folders, w.folderDepth)
 	AttachProfiles(folders, profileItems)
-	this.protectedRead(func() { MarkIgnored(folders, this.ignoredFolders) })
+	w.protectedRead(func() { MarkIgnored(folders, w.ignoredFolders) })
 
 	active := ActiveFolders(folders)
 	checksum = int64(len(active))
@@ -148,36 +147,36 @@ func (this *Watcher) gather() (folders messaging.Folders, checksum int64) {
 	return folders, checksum
 }
 
-func (this *Watcher) set(state int64) {
-	this.fileSystemState = state
+func (w *Watcher) set(state int64) {
+	w.fileSystemState = state
 }
 
-func (this *Watcher) sendToExecutor(folders messaging.Folders) {
-	this.output <- folders
+func (w *Watcher) sendToExecutor(folders messaging.Folders) {
+	w.output <- folders
 }
 
-func (this *Watcher) ignore(paths string) {
-	this.protectedWrite(func() {
+func (w *Watcher) ignore(paths string) {
+	w.protectedWrite(func() {
 		for _, folder := range strings.Split(paths, string(os.PathListSeparator)) {
-			this.ignoredFolders[folder] = struct{}{}
-			log.Println("Currently ignored folders:", this.ignoredFolders)
+			w.ignoredFolders[folder] = struct{}{}
+			log.Println("Currently ignored folders:", w.ignoredFolders)
 		}
 	})
 }
-func (this *Watcher) reinstate(paths string) {
-	this.protectedWrite(func() {
+func (w *Watcher) reinstate(paths string) {
+	w.protectedWrite(func() {
 		for _, folder := range strings.Split(paths, string(os.PathListSeparator)) {
-			delete(this.ignoredFolders, folder)
+			delete(w.ignoredFolders, folder)
 		}
 	})
 }
-func (this *Watcher) protectedWrite(protected func()) {
-	this.lock.Lock()
-	defer this.lock.Unlock()
+func (w *Watcher) protectedWrite(protected func()) {
+	w.lock.Lock()
+	defer w.lock.Unlock()
 	protected()
 }
-func (this *Watcher) protectedRead(protected func()) {
-	this.lock.RLock()
-	defer this.lock.RUnlock()
+func (w *Watcher) protectedRead(protected func()) {
+	w.lock.RLock()
+	defer w.lock.RUnlock()
 	protected()
 }


### PR DESCRIPTION
These integration tests were very flaky before. Running them repeatedly, e.g. by `while true; do go test -count=1 ./web/server/watch; done`, would lead to different errors each time on assertions about watcher results outputs.

I traced this back to integration.go's Watcher.Listen(). This function is designed to loop forever, each time looking for changes in the local filesystem, then responding if it does find changes. It's all really janky, to be honest. The problem here was that the tests were very sensitive to when input commands came in. If the recipient got two commands quickly, then you'd have the two commands processed before a scan could happen (in the select's default case). With this change, the select will always do a scan after each command is run, and it also won't sleep unnecessarily while a command is arriving.

This required an update to one test, because this caused it to run scan twice more, which is innocuous and fine.

I think this code is used for filewatching for the test web UI, and I confirmed locally that it still works.