### PR TITLE
Support all xterm variants with color

### DIFF
--- a/convey/reporting/init.go
+++ b/convey/reporting/init.go
@@ -84,7 +84,7 @@ func monochrome() {
 }
 
 func isColorableTerminal() bool {
-  term := os.Getenv("TERM")
+	term := os.Getenv("TERM")
 	return strings.Contains(term, "color") || strings.Contains(term, "xterm")
 }
 

--- a/convey/reporting/init.go
+++ b/convey/reporting/init.go
@@ -84,7 +84,8 @@ func monochrome() {
 }
 
 func isColorableTerminal() bool {
-	return strings.Contains(os.Getenv("TERM"), "color")
+  term := os.Getenv("TERM")
+	return strings.Contains(term, "color") || strings.Contains(term, "xterm")
 }
 
 // This interface allows us to pass the *testing.T struct


### PR DESCRIPTION
I see from the history that how to support color or not has been changed a few times. Originally it supported any `TERM` var that contained `xterm`. Then it was looking at `TERM` for `256`. Now it looks for `color`.

Some modern terminals, e.g. Kitty, have their own terminal type in order to support extended integration between the shell and the terminal. Kitty's default terminal type is `xterm-kitty`. I could hack around this by renaming it, however, I feel like `goconvey` should probably support modern terminals like this.

Probably the better strategy at this point is to have an env var that _disables_ color. However, I did not attempt to mess with that here.

I've been using `xterm` since at least 1992 and AFAIK it has supported color since well before then. `goconvey` is not using colors beyond the standard range (e.g. not using 256 color range). So I'm proposing here that `goconvey` **also** support color on any terminals with a `TERM` var containing `xterm`. This should not affect the behavior of anyone with other terminals on which color is currently supported.