### PR TITLE
chore: update file-path link on failure output

### DIFF
--- a/convey/reporting/init.go
+++ b/convey/reporting/init.go
@@ -55,8 +55,8 @@ var (
 	dotFailure      = "x"
 	dotError        = "E"
 	dotSkip         = "S"
-	errorTemplate   = "* %s \nLine %d: - %v \n%s\n"
-	failureTemplate = "* %s \nLine %d:\n%s\n"
+	errorTemplate   = "* %s:%d \nLine %d: - %v \n%s\n"
+	failureTemplate = "* %s:%d \nLine %d:\n%s\n"
 	stackTemplate   = "%s\n"
 )
 

--- a/convey/reporting/problems.go
+++ b/convey/reporting/problems.go
@@ -44,7 +44,7 @@ func (self *problem) showErrors() {
 			self.out.Println("\nErrors:\n")
 			self.out.Indent()
 		}
-		self.out.Println(errorTemplate, e.File, e.Line, e.Error, e.StackTrace)
+		self.out.Println(errorTemplate, e.File, e.Line, e.Line, e.Error, e.StackTrace)
 	}
 }
 func (self *problem) showFailures() {
@@ -53,7 +53,7 @@ func (self *problem) showFailures() {
 			self.out.Println("\nFailures:\n")
 			self.out.Indent()
 		}
-		self.out.Println(failureTemplate, f.File, f.Line, f.Failure)
+		self.out.Println(failureTemplate, f.File, f.Line, f.Line, f.Failure)
 		if f.StackTrace != "" {
 			self.out.Println(stackTemplate, f.StackTrace)
 		}


### PR DESCRIPTION
As mentioned in this issue: https://github.com/smartystreets/goconvey/issues/698

It is a real pain when running tests in an IDE that the output string on failure does not follow the standard pattern to a clickable `file:line` link. 

This PR simply changes the output to also contain the line number in the file-path output line on failure.