### PR TITLE
feat: add tlog reporter for parallel-safe test output

### DIFF
--- a/convey/init.go
+++ b/convey/init.go
@@ -43,6 +43,8 @@ func buildReporter() reporting.Reporter {
 		return reporting.BuildJsonReporter()
 	case silent || selectReporter == "silent":
 		return reporting.BuildSilentReporter()
+	case selectReporter == "tlog":
+		return reporting.BuildTLogReporter()
 	case selectReporter == "dot":
 		// Story is turned on when verbose is set, so we need to check for dot reporter first.
 		return reporting.BuildDotReporter()

--- a/convey/reporting/init.go
+++ b/convey/reporting/init.go
@@ -38,6 +38,11 @@ func BuildStoryReporter() Reporter {
 		NewProblemReporter(out),
 		consoleStatistics)
 }
+func BuildTLogReporter() Reporter {
+	return NewReporters(
+		NewGoTestReporter(),
+		NewTLogReporter())
+}
 func BuildSilentReporter() Reporter {
 	out := NewPrinter(NewConsole())
 	return NewReporters(

--- a/convey/reporting/tlog.go
+++ b/convey/reporting/tlog.go
@@ -1,0 +1,85 @@
+package reporting
+
+import (
+	"bytes"
+	"strings"
+)
+
+type testLogger interface {
+	Logf(format string, args ...any)
+}
+
+type tlogReporter struct {
+	test testLogger
+}
+
+func (self *tlogReporter) BeginStory(story *StoryReport) {
+	if story == nil || story.Test == nil {
+		self.test = nil
+		return
+	}
+	if logger, ok := story.Test.(testLogger); ok {
+		self.test = logger
+	}
+}
+
+func (self *tlogReporter) Enter(scope *ScopeReport) {
+	if self.test == nil || scope == nil {
+		return
+	}
+	self.test.Logf("Convey: %s", scope.Title)
+}
+
+func (self *tlogReporter) Report(r *AssertionResult) {
+	if self.test == nil || r == nil {
+		return
+	}
+	if r.Error != nil {
+		self.test.Logf("ERROR: %v (%s:%d)", r.Error, r.File, r.Line)
+		if r.StackTrace != "" {
+			self.test.Logf("%s", r.StackTrace)
+		}
+		return
+	}
+	if r.Failure != "" {
+		self.test.Logf("FAIL: %s (%s:%d)", r.Failure, r.File, r.Line)
+		if r.Expected != "" || r.Actual != "" {
+			self.test.Logf("expected: %s", r.Expected)
+			self.test.Logf("actual:   %s", r.Actual)
+		}
+		if r.StackTrace != "" {
+			self.test.Logf("%s", r.StackTrace)
+		}
+		return
+	}
+	if r.Skipped {
+		self.test.Logf("SKIP (%s:%d)", r.File, r.Line)
+	}
+}
+
+func (self *tlogReporter) Exit() {}
+
+func (self *tlogReporter) EndStory() {
+	self.test = nil
+}
+
+func (self *tlogReporter) Write(content []byte) (written int, err error) {
+	if self.test == nil {
+		return len(content), nil
+	}
+	trimmed := bytes.TrimSpace(content)
+	if len(trimmed) == 0 {
+		return len(content), nil
+	}
+	for _, line := range strings.Split(string(trimmed), "\n") {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		self.test.Logf("%s", line)
+	}
+	return len(content), nil
+}
+
+func NewTLogReporter() *tlogReporter {
+	return new(tlogReporter)
+}


### PR DESCRIPTION
Add a new 'tlog' reporter that routes all GoConvey output through t.Log() instead of fmt.Print(stdout). This allows tests using t.Parallel() to have properly attributed, non-interleaved output in Go's test framework.

Activate via GOCONVEY_REPORTER=tlog environment variable.